### PR TITLE
A fix to issue #14.

### DIFF
--- a/alex/components/asr/utterance.py
+++ b/alex/components/asr/utterance.py
@@ -259,7 +259,7 @@ class Utterance(object):
             if self._utterance[match_idx] == initial:
                 # Check the subsequent words too.
                 for phrase_idx in xrange(1, len(phrase)):
-                    if self._utterance[match_idx + phrase_idx] !=\
+                    if self._utterance[match_idx + phrase_idx] != \
                             phrase[phrase_idx]:
                         break
                 else:
@@ -305,6 +305,15 @@ class Utterance(object):
 
         return (ret_utt, orig_pos) if return_startidx else ret_utt
 
+    def replace_all(self, orig, replacement):
+        if self.find(orig) == -1:
+            return self
+        if isinstance(orig, list):
+            orig = u' '.join(orig)
+        if isinstance(replacement, list):
+            replacement = u' '.join(replacement)
+        return Utterance(unicode(self).replace(orig, replacement))
+
     def replace2(self, start, end, replacement):
         """
         Replace the words from start to end with the replacement.
@@ -317,7 +326,7 @@ class Utterance(object):
 
         ret_utt = Utterance('')
         if not isinstance(replacement, list):
-            replacement = [replacement,]
+            replacement = [replacement, ]
 
         ret_utt.utterance = self._utterance[:start] + replacement + self._utterance[end:]
         ret_utt._wordset = set(ret_utt._utterance)
@@ -368,7 +377,7 @@ class Utterance(object):
 # TODO Extend to AbstractedLattice.
 # TODO Write tests.
 class AbstractedUtterance(Utterance, Abstracted):
-    other_val = ('[OTHER]', )
+    other_val = ('[OTHER]',)
 
     def __init__(self, surface):
         self._abstr_idxs = list()  # sorted in an increasing order
@@ -397,7 +406,7 @@ class AbstractedUtterance(Utterance, Abstracted):
         try:
             return hash((tuple(self._utterance), tuple(self._abstr_idxs)))
         except AttributeError:
-            return hash((('_other_', ), tuple()))
+            return hash((('_other_',), tuple()))
 
     @classmethod
     def from_utterance(cls, utterance):
@@ -408,14 +417,14 @@ class AbstractedUtterance(Utterance, Abstracted):
 
     @classmethod
     def make_other(cls, type_):
-        return (u'{t}-OTHER'.format(t=type_[0]), )
+        return (u'{t}-OTHER'.format(t=type_[0]),)
 
     def join_typeval(self, type_, val):
-        return (self.splitter.join((type_[0], ' '.join(val))), )
+        return (self.splitter.join((type_[0], ' '.join(val))),)
 
     def iter_typeval(self):
         for idx in self._abstr_idxs:
-            yield (self._utterance[idx], )
+            yield (self._utterance[idx],)
 
     def iter_triples(self):
         for combined_el, in self.iter_typeval():
@@ -427,7 +436,7 @@ class AbstractedUtterance(Utterance, Abstracted):
                 type_ = split[0] if combined_el else ''
             # XXX Change the order of return values to combined_el, type_,
             # value.
-            yield (combined_el, ), tuple(value.split(' ')), (type_, )
+            yield (combined_el,), tuple(value.split(' ')), (type_,)
 
     def phrase2category_label(self, phrase, catlab):
         """Replaces the phrase given by `phrase' by a new phrase, given by
@@ -436,7 +445,7 @@ class AbstractedUtterance(Utterance, Abstracted):
         """
         combined_el = self.splitter.join((' '.join(catlab),
                                           ' '.join(phrase)))
-        return self.replace(phrase, (combined_el, ))
+        return self.replace(phrase, (combined_el,))
 
     def replace(self, orig, replacement):
         """
@@ -529,7 +538,7 @@ class UtteranceFeatures(Features):
         elif self.type == 'ngram':
             # Compute shorter n-grams.
             for word in utterance:
-                self.features[(word, )] += 1.
+                self.features[(word,)] += 1.
             if self.size >= 2:
                 for ngram in utterance.iter_ngrams(
                         2, with_boundaries=with_boundaries):
@@ -592,7 +601,7 @@ class UtteranceNBList(ASRHypothesis, NBList):
                 most probable to the least probable ones
 
     """
-    def __init__(self, rep = None):
+    def __init__(self, rep=None):
         NBList.__init__(self)
 
         if rep:
@@ -708,7 +717,7 @@ class UtteranceConfusionNetwork(ASRHypothesis, Abstracted):
     fact) with easy-to-read indexing. namedtuple might be the best choice.
 
     """
-    other_val = ('[OTHER]', )
+    other_val = ('[OTHER]',)
     repr_spec_chars = '():,;|[]"\\'
     repr_escer = Escaper(repr_spec_chars)
     str_escer = Escaper('"\\')  # Python string literal escaper
@@ -935,18 +944,18 @@ class UtteranceConfusionNetwork(ASRHypothesis, Abstracted):
     # Abstracted implementations.
     @classmethod
     def make_other(cls, type_):
-        return (u'{t}-OTHER'.format(t=type_[0]), )
+        return (u'{t}-OTHER'.format(t=type_[0]),)
 
     def iter_typeval(self):
         for index in self._abstr_idxs:
             if index.is_long_link:
                 yield (self._long_links[index.word_idx][index.alt_idx]
-                       .hyp[1][0], )
+                       .hyp[1][0],)
             else:
-                yield (self._cn[index.word_idx][index.alt_idx][1], )
+                yield (self._cn[index.word_idx][index.alt_idx][1],)
 
     def join_typeval(self, type_, val):
-        return (self.splitter.join((type_[0], ' '.join(val))), )
+        return (self.splitter.join((type_[0], ' '.join(val))),)
 
     def replace_typeval(self, combined, replacement):
         replaced, old_idxs, new_idxs = self._replace(
@@ -967,7 +976,7 @@ class UtteranceConfusionNetwork(ASRHypothesis, Abstracted):
                 type_ = split[0] if combined_el else ''
             # XXX Change the order of return values to combined_el, type_,
             # value.
-            yield (combined_el, ), tuple(value.split(' ')), (type_, )
+            yield (combined_el,), tuple(value.split(' ')), (type_,)
 
     # Methods to support preprocessing.
     def lower(self):
@@ -994,7 +1003,7 @@ class UtteranceConfusionNetwork(ASRHypothesis, Abstracted):
         """
         combined_el = self.splitter.join((' '.join(catlab), ' '.join(phrase)))
         replaced, old_idxs, new_idxs = self._replace(
-            phrase, (combined_el, ), keep=True)
+            phrase, (combined_el,), keep=True)
         if old_idxs:
             replaced._abstr_idxs = [idx for idx in replaced._abstr_idxs
                                     if idx._replace(link_widx=0)
@@ -1691,7 +1700,7 @@ class UtteranceConfusionNetwork(ASRHypothesis, Abstracted):
         # Find n-gram start indices that shall be iterated over.
         if start is not None:
             if start < len(self._cn):
-                start_iter = (start, )
+                start_iter = (start,)
             elif start == len(self._cn) and with_boundaries:
                 start_iter = tuple()
             else:
@@ -1831,7 +1840,7 @@ class UtteranceConfusionNetworkFeatures(Features):
             for alts in confnet:
                 for prob, word in alts:
                     if word:  # skip empty words
-                        self.features[(word, )] += prob
+                        self.features[(word,)] += prob
             if self.size >= 2:
                 for prob, ngram in confnet.iter_ngrams(
                         2, with_boundaries=True):

--- a/alex/components/slu/base.py
+++ b/alex/components/slu/base.py
@@ -144,7 +144,7 @@ class CategoryLabelDatabase(object):
             self._form_upnames_vals = \
                 [(form, dict(upnames_vals))
                  for (form, upnames_vals) in
-                 sorted(upnames_vals4form.viewitems(), key=lambda item: -len(item[0]))]
+                 sorted(upnames_vals4form.viewitems(), key=lambda item:-len(item[0]))]
         return self._form_upnames_vals
 
     def load(self, file_name):
@@ -262,7 +262,7 @@ class SLUPreprocessing(object):
         utterance.lower()
 
         for mapping in self.text_normalization_mapping:
-            utterance = utterance.replace(mapping[0], mapping[1])
+            utterance = utterance.replace_all(mapping[0], mapping[1])
         return utterance
 
     def normalise_nblist(self, nblist):
@@ -302,7 +302,7 @@ class SLUPreprocessing(object):
             raise SLUException("Unsupported observations.")
 
     # TODO Update the docstring for the `all_options' argument.
-    def values2category_labels_in_utterance(self, utterance,all_options=False):
+    def values2category_labels_in_utterance(self, utterance, all_options=False):
         """Replaces strings matching surface forms in the label database with
         their slot names plus index.
 


### PR DESCRIPTION
The wrong parsing actually only happened if you used digits instead of spelled-out number words in THUB (or if Google ASR returned digits in their n-best lists).

The problem was that in the preprocessing phase, each occurrence of a word to be normalized was only replaced once. I changed it to replacing all occurrences of such words.
