### PR TITLE
Fix to Google error OVER_QUERY_LIMIT

### DIFF
--- a/alex/applications/PublicTransportInfoCS/hdc_policy.py
+++ b/alex/applications/PublicTransportInfoCS/hdc_policy.py
@@ -757,10 +757,14 @@ class PTICSHDCPolicy(DialoguePolicy):
         if not isinstance(dialogue_state['route_alternative'], int):
             dialogue_state['route_alternative'] = 0
 
-        route = dialogue_state.directions.routes[dialogue_state['route_alternative']]
-
-        # only 1 leg should be present in case we have no waypoints
-        steps = route.legs[0].steps
+        try:
+            # get the alternative we want to say now
+            route = dialogue_state.directions.routes[dialogue_state['route_alternative']]
+            # only 1 leg should be present in case we have no waypoints
+            steps = route.legs[0].steps
+        except IndexError:
+            # this will lead to apology that no route has been found
+            steps = []
 
         res = []
 
@@ -815,8 +819,8 @@ class PTICSHDCPolicy(DialoguePolicy):
         # no route found: apologize
         if len(res) == 0:
             res.append('apology()')
-            res.append("inform(from_stop='%s')" % dialogue_state['from_stop'].mpv())
-            res.append("inform(to_stop='%s')" % dialogue_state['to_stop'].mpv())
+            res.append("inform(from_stop='%s')" % dialogue_state.directions.from_stop)
+            res.append("inform(to_stop='%s')" % dialogue_state.directions.to_stop)
 
         res_da = DialogueAct("&".join(res))
 

--- a/alex/tools/apirequest.py
+++ b/alex/tools/apirequest.py
@@ -7,6 +7,23 @@ from datetime import datetime
 import os
 import codecs
 import json
+import sys
+
+
+class DummyLogger():
+    """A dummy logger implementation for debugging purposes that will just print to STDERR."""
+
+    def __init__(self):
+        pass
+
+    def info(self, text):
+        print >> sys.stderr, text.encode('UTF-8')
+
+    def external_data_file(self, dummy1, dummy2):
+        pass
+
+    def get_session_dir_name(self):
+        return ''
 
 
 class APIRequest(object):
@@ -17,13 +34,18 @@ class APIRequest(object):
         prefixes and the name of the referring XML element in the system log.
 
         :param cfg: System configuration, containing the entries \
-                ['Logging']['system_logger'] and ['Logging']['session_logger']
+                ['Logging']['system_logger'] and ['Logging']['session_logger'] \
+                (A dummy logger with outputs to STDERR and current directory \
+                is used if these entries are not present).
         :param fname_prefix: File name prefix for dumps of responses
         :param log_elem_name: Name of the system log XML element referring to \
                 the dump file
         """
-        self.system_logger = cfg['Logging']['system_logger']
-        self.session_logger = cfg['Logging']['session_logger']
+        self.system_logger = DummyLogger()
+        self.session_logger = DummyLogger()
+        if 'Logging' in cfg:
+            self.system_logger = cfg['Logging']['system_logger']
+            self.session_logger = cfg['Logging']['session_logger']
         self.fname_prefix = fname_prefix
         self.logger_name = log_elem_name
 


### PR DESCRIPTION
When Google issues an OVER_QUERY_LIMIT error (for asking too often? I don't know), the application would fail with an index-out-of-range error. This fixes it by telling the user we cannot found any connection.

This should handle any other error issued by Google as well.

Added are a few tricks for the debugging of the Google API (if no logger is specified in constructor, will just print to STDERR).
