### PR TITLE
Fixing implicit repeats

### DIFF
--- a/alex/applications/PublicTransportInfoCS/hdc_policy.py
+++ b/alex/applications/PublicTransportInfoCS/hdc_policy.py
@@ -372,11 +372,11 @@ class PTICSHDCPolicy(DialoguePolicy):
         :param ds: The current dialogue state
         :rtype: DialogueAct
         """
-        if randbool(6):
+        if randbool(10):
             return self.get_limited_context_help(ds)
-        elif randbool(5):
+        elif randbool(9):
             return DialogueAct('reqmore()')
-        elif randbool(4):
+        elif randbool(8):
             return DialogueAct('notunderstood()')
         elif randbool(3):
             return DialogueAct('irepeat()')

--- a/alex/components/nlg/template.py
+++ b/alex/components/nlg/template.py
@@ -249,30 +249,33 @@ class AbstractTemplateNLG(object):
         Then try to find a relaxed match of a more generic template and
         fill in the actual values of the variables.
         """
+        utterance = ''
         try:
             if unicode(da) == 'irepeat()':
                 # just return last utterance
-                pass
+                utterance = self.last_utterance
             else:
                 # try to return exact match
-                self.last_utterance = self.random_select(self.templates[unicode(da)])
+                utterance = self.random_select(self.templates[unicode(da)])
         except KeyError:
             # try to find a relaxed match
             svs = da.get_slots_and_values()
 
             try:
-                self.last_utterance = self.match_and_fill_generic(da, svs)
+                utterance = self.match_and_fill_generic(da, svs)
 
             except TemplateNLGException:
                 # try to find a template for each dialogue act item and concatenate them
                 try:
-                    self.last_utterance = self.compose_utterance(da)
+                    utterance = self.compose_utterance(da)
 
                 except TemplateNLGException:
                     # nothing to do, I must backoff
-                    self.last_utterance = self.backoff(da)
+                    utterance = self.backoff(da)
 
-        return self.last_utterance
+        if re.match(r'^(inform|i?confirm|request|hello)', unicode(da)):
+            self.last_utterance = utterance
+        return utterance
 
     def compose_utterance_single(self, da):
         """\


### PR DESCRIPTION
Implicit repeats now only target inform, confirm, iconfirm, request and hello system utterances.

The system is more likely to issue an irepeat() or silence() in case of backoff dialogue action (state unchanged).
