### PR TITLE
Fix for CRWS not returning the _sNum2 attribute

### DIFF
--- a/alex/applications/PublicTransportInfoCS/directions.py
+++ b/alex/applications/PublicTransportInfoCS/directions.py
@@ -327,7 +327,10 @@ class CRWSRouteStep(RouteStep):
                 self.line_name = ''
             # replace train numbers with names (e.g. 'Hutník', 'Pendolino' etc.) or nothing
             if self.vehicle.endswith('train'):
-                self.line_name = input_data.oTrainData.oInfo._sNum2 or ''
+                self.line_name = (input_data.oTrainData.oInfo._sNum2
+                                  if hasattr(input_data.oTrainData.oInfo, '_sNum2')
+                                  and input_data.oTrainData.oInfo
+                                  else '')
                 if self.line_name:  # strip train type shortcut if it's contained in the name
                     train_type_shortcut = input_data.oTrainData.oInfo._sType
                     if self.line_name.startswith(train_type_shortcut + ' '):
@@ -525,6 +528,9 @@ class CRWSDirectionsFinder(DirectionsFinder, APIRequest):
             TTDETAILS.ROUTE_FROMTO | TTDETAILS.ROUTE_CHANGE | TTDETAILS.TRAIN_INFO,
             TTLANG.ENGLISH,
             0)
+        # (use this to log raw XML responses as returned by CRWS)
+        # # xml_response = unicode(self.client.last_received())
+        # # self.session_logger.external_data_file(ftype, fname, xml_response.encode('UTF-8'))
         # log the response
         self._log_response_json(_todict(response, '_origClassName'))
         # parse the results

--- a/alex/tools/apirequest.py
+++ b/alex/tools/apirequest.py
@@ -5,21 +5,27 @@ from __future__ import unicode_literals
 
 from datetime import datetime
 import os
-import codecs
 import json
 import sys
 
 
 class DummyLogger():
-    """A dummy logger implementation for debugging purposes that will just print to STDERR."""
+    """A dummy logger implementation for debugging purposes that will just print
+    to STDERR or whatever output stream it is given in the constructor."""
 
-    def __init__(self):
+    def __init__(self, stream=sys.stderr):
+        """\
+        @param stream: The output stream, defaults to sys.stderr
+        """
+        self.stream = stream
         pass
 
     def info(self, text):
-        print >> sys.stderr, text.encode('UTF-8')
+        print >> self.stream, text.encode('UTF-8')
 
-    def external_data_file(self, dummy1, dummy2):
+    def external_data_file(self, dummy1, dummy2, data):
+        print >> self.stream, data
+        self.stream.flush()
         pass
 
     def get_session_dir_name(self):

--- a/alex/utils/sessionlogger.py
+++ b/alex/utils/sessionlogger.py
@@ -23,7 +23,7 @@ from alex.utils.procname import set_proc_name
 
 class SessionLogger(multiprocessing.Process):
     """
-    This is a multiprocessing-safe logger. It should be used by the alex to log
+    This is a multiprocessing-safe logger. It should be used by Alex to log
     information according the SDC 2010 XML format.
 
     Date and times should also include time zone.


### PR DESCRIPTION
CRWS may not indicate the _sNum2 attribute in some TrainInfo instances.
The SUDS library will not initialize it to any default value and keep it
as missing. This checks the presence of this attribute before it is
used.

Additional small bugfixes to debug logging in DummyLogger, comments only
in SessionLogger.
