### PR TITLE
Rounding departure time to the start of the next minute

### DIFF
--- a/alex/applications/PublicTransportInfoCS/hdc_policy.py
+++ b/alex/applications/PublicTransportInfoCS/hdc_policy.py
@@ -1043,7 +1043,7 @@ class PTICSHDCPolicy(DialoguePolicy):
         :rtype: tuple(datetime, string)
         """
         now = datetime.now()
-        now -= timedelta(seconds=now.second, microseconds=now.microsecond)  # floor to minute start
+        now += timedelta(seconds=(60 - now.second), microseconds=(-now.microsecond))  # round to next minute start
 
         # use only last-talked-about time (of any type -- departure/arrival)
         if (time_abs != 'none' or date_rel != 'none') and time_rel != 'none':


### PR DESCRIPTION
The departure time is rounded not to the start of the current minute,
but rather to the start of the next minute.
