### PR TITLE
Preventing "silence()" from being passed to TTS

### DIFF
--- a/alex/applications/PublicTransportInfoCS/nlg_templates.cfg
+++ b/alex/applications/PublicTransportInfoCS/nlg_templates.cfg
@@ -6,6 +6,9 @@ from __future__ import unicode_literals
 templates = {
     'say(text={text})':
         '{text}',
+        
+    'silence()':
+        '',
 
     'affirm()':
         'Ano.',


### PR DESCRIPTION
In some cases, the DM can output DAs like `notunderstood()&silence()` since `silence()` is sometimes returned by [`get_limited_context_help()`](https://github.com/UFAL-DSG/alex/blob/master/alex/applications/PublicTransportInfoCS/hdc_policy.py#L1142).

These are then not caught by NLG (since it's not only `silence()`) and `silence()` makes its way to TTS.

Introducing an empty template for `silence()` will effectively strip these DAIs from the output.
