### PR TITLE
Fix for star slot values sifting through to the output

### DIFF
--- a/alex/applications/PublicTransportInfoCS/hdc_policy.py
+++ b/alex/applications/PublicTransportInfoCS/hdc_policy.py
@@ -18,7 +18,6 @@ from datetime import datetime
 from datetime import time as dttime
 from collections import defaultdict
 import re
-from wx import ACCEL_ALT
 
 
 def randbool(n):


### PR DESCRIPTION
Since e601356, SLU will sometimes produce outputs such as `inform(from_stop="*")`, where the value has no meaning (we only know the user mentioned the slot). However, it was still interpreted as an ordinary value, leading to weird prompts such as:

```
OK, from the stop *.
```

This fix makes HDC policy ignore all `*` values.

However, `*` still stays in dialogue tracking and changes the behavior of the policy. A permanent fix should
probably interpret it somehow.
