### PR TITLE
Fix dependencies and error to allow dailrclassifier training on MetaCentrum

### DIFF
--- a/alex/components/asr/__init__.py
+++ b/alex/components/asr/__init__.py
@@ -1,5 +1,3 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # This code is PEP8-compliant. See http://www.python.org/dev/peps/pep-0008.
-
-from alex.components.asr.base import *

--- a/alex/components/slu/dailrclassifier.py
+++ b/alex/components/slu/dailrclassifier.py
@@ -677,7 +677,7 @@ class DAILogRegClassifier(SLUInterface):
                 print "Training classifier: ", clser, ' #', n+1 , '/', len(self.classifiers)
                 print "  Matrix:            ", (len(self.classifiers_outputs[clser]), len(self.classifiers_features_list[clser]))
 
-            classifier_input = np.zeros((training_data_size, len(self.classifiers_features_list[clser])))
+            classifier_input = np.zeros((len(self.classifiers_outputs[clser]), len(self.classifiers_features_list[clser])))
             for i, feat in enumerate(self.classifiers_features[clser]):
                 classifier_input[i] = feat.get_feature_vector(self.classifiers_features_mapping[clser])
 


### PR DESCRIPTION
Remove unnecessary dependencies of SLU to audio libraries caused by importing alex.components.asr.base in module initialization.
Remove undefined training_data_size variable call
