### PR TITLE
Fix for missing via_stop and via_city templates

### DIFF
--- a/alex/applications/PublicTransportInfoCS/nlg_templates.cfg
+++ b/alex/applications/PublicTransportInfoCS/nlg_templates.cfg
@@ -361,6 +361,9 @@ templates = {
     'iconfirm(to_stop={to_stop})&iconfirm(from_stop={from_stop})':
         "Dobře, ze zastávky {from_stop} do zastávky {to_stop}.",
 
+    'iconfirm(via_stop={via_stop})':
+        "Přes zastávku {via_stop}.",
+
     'iconfirm(arrival_time="{arrival_time}")':
         "Chcete tam být v {arrival_time}.",
 
@@ -502,6 +505,9 @@ templates = {
     'iconfirm(in_city={in_city})':
         "V obci {in_city}.",
 
+    'iconfirm(via_city={via_city})':
+        "Přes obec {via_city}.",
+
     'iconfirm(to_city={to_city})&iconfirm(from_city={from_city})':
         "Dobře, z obce {from_city} do obce {to_city}.",
 
@@ -537,6 +543,12 @@ templates = {
     'confirm(in_city={in_city})':
         ("Říkáte obec {in_city}?",
          "Říkáte město {in_city}?",),
+
+    'confirm(via_stop={via_stop})':
+        "Chcete jet přes zastávku {via_stop}?",
+
+    'confirm(via_city={via_city})':
+        "Chcete jet přes obec {via_city}?",
 
     'confirm(arrival_time="{arrival_time}")':
         "Takže tam chcete být v {arrival_time}?",
@@ -592,11 +604,17 @@ templates = {
     'select(to_stop={to_stop1})&select(to_stop={to_stop2})':
         "Chcete jet do zastávky {to_stop1}, nebo {to_stop2}?",
 
+    'select(via_stop={via_stop1})&select(via_stop={via_stop2})':
+        "Chcete jet přes zastávku {via_stop1}, nebo {via_stop2}?",
+
     'select(from_city={from_city1})&select(from_city={from_city2})':
         "Chcete jet z města {from_city1}, nebo {from_city2}?",
 
     'select(to_city={to_city1})&select(to_city={to_city2})':
         "Chcete jet do města {to_city1}, nebo {to_city2}?",
+
+    'select(via_city={via_city1})&select(via_city={via_city2})':
+        "Chcete jet přes obec {via_city1}, nebo {via_city2}?",
 
     'select(in_city={in_city1})&select(in_city={in_city2})':
         "Chcete {in_city1}, nebo {in_city2}?",


### PR DESCRIPTION
Adding templates for iconfirm, confirm and select actions on via_stop and via_city slots. The system is still not able to use this information when searching for directions, but at least the TTS will not fail.