### PR TITLE
fix changes from new pykaldi api

### DIFF
--- a/alex/applications/PublicTransportInfoCS/hclg/kaldi.cfg
+++ b/alex/applications/PublicTransportInfoCS/hclg/kaldi.cfg
@@ -43,7 +43,7 @@ config = {
             'silent_phones': online_update('applications/PublicTransportInfoCS/hclg/models/silence.csl'),
             # The HCLG requires matching *.mdl and silence.csl, so be sure it was build using the models above!
             'hclg': online_update('applications/PublicTransportInfoCS/hclg/models/HCLG_tri2b_bmmi.fst'),
-            'extra_args': '  --max-mem=10000000000 --lat-lm-scale=10 --beam=12.0 --lattice-beam=5.0 --max-active=2000',  # pg CLASS LM weight 0.8
+            'extra_args': '  --max-mem=10000000000 --acoustic-scale=0.1 --beam=12.0 --lattice-beam=5.0 --max-active=2000',  # pg CLASS LM weight 0.8
             # new LM WER=21.77 dev=4130 uni.samp. old am 95%RTF=1.11 95%FWRTF=0.57 95%LAT=0.27 95%FWLAT=0.00 'extra_args': '  --max-mem=10000000000 --lat-lm-scale=10 --beam=12.0 --lattice-beam=5.0 --max-active=2000',  # pg CLASS LM weight 0.8
             # new LM WER=21.52 dev=3759 uni.samp. old am 95%RTF=1.09 95%FWRTF=0.58 95%LAT=0.25 95%FWLAT=0.00 'extra_args': '  --max-mem=10000000000 --lat-lm-scale=10 --beam=12.0 --lattice-beam=5.0 --max-active=2000',  # pg CLASS LM weight 0.8
             # new LM and AM on all data WER=18.4 dev=3016 uni.samp 'extra_args': '  --max-mem=10000000000 --lat-lm-scale=10 --beam=12.0 --lattice-beam=5.0 --max-active=2000',  # pg CLASS LM weight 0.8

--- a/alex/applications/PublicTransportInfoCS/hclg/kaldi_last.cfg
+++ b/alex/applications/PublicTransportInfoCS/hclg/kaldi_last.cfg
@@ -43,7 +43,7 @@ config = {
             'silent_phones': online_update('applications/PublicTransportInfoCS/hclg/models_last/silence.csl'),
             # The HCLG requires matching *.mdl and silence.csl, so be sure it was build using the models above!
             'hclg': online_update('applications/PublicTransportInfoCS/hclg/models_last/HCLG_tri2b_bmmi.fst'),
-            'extra_args': '  --max-mem=10000000000 --lat-lm-scale=10 --beam=12.0 --lattice-beam=5.0 --max-active=2000',  # pg CLASS LM weight 0.8
+            'extra_args': '  --max-mem=10000000000 --acoustic-scale=0.1 --beam=12.0 --lattice-beam=5.0 --max-active=2000',  # pg CLASS LM weight 0.8
             # WER=18.2 dev=3016 new LM new AM all available data 95%RTF=1.09 95%FWRTF=0.49 95%LAT=0.25 95%FWLAT=0.00 'extra_args': '  --max-mem=10000000000 --lat-lm-scale=10 --beam=12.0 --lattice-beam=5.0 --max-active=2000',  # pg CLASS LM weight 0.8     
             # WER=15.8 dev=1481 uni.samp. '95%RTF=1.07 95%FWRTF=0.45 95%LAT=0.17 95%FWLAT=0.00  'extra_args': '  --max-mem=10000000000 --lat-lm-scale=10 --beam=12.0 --lattice-beam=5.0 --max-active=2000',  # pg CLASS LM weight 0.8
         },

--- a/alex/components/asr/pykaldi.py
+++ b/alex/components/asr/pykaldi.py
@@ -48,8 +48,6 @@ class KaldiASR(ASRInterface):
         self.wst = kaldi.utils.wst2dict(kcfg['wst'])
         self.max_dec_frames = kcfg['max_dec_frames']
         self.n_best = kcfg['n_best']
-        if not 'matrix' in kcfg:
-            kcfg['matrix'] = ''  # some models e.g. tri2a does not use matrix
 
         # specify all other options in config
         argv = ("--config=%(config)s --verbose=%(verbose)d %(extra_args)s "
@@ -73,7 +71,7 @@ class KaldiASR(ASRInterface):
         Returns:
             self - The instance of KaldiASR
         """
-        self.decoder.reset(keep_buffer_data=False)
+        self.decoder.reset(reset_pipeline=True)
         return self
 
     def rec_in(self, frame):
@@ -112,9 +110,9 @@ class KaldiASR(ASRInterface):
         start = time.time()
 
         # Get hypothesis
-        self.decoder.prune_final()
+        self.decoder.finalize_decoding()
         utt_lik, lat = self.decoder.get_lattice()  # returns acceptor (py)fst.LogVectorFst
-        self.decoder.reset(keep_buffer_data=False)
+        self.decoder.reset(reset_pipeline=False)
 
         if self.calibration_table:
             lat = lattice_calibration(lat, self.calibration_table)
@@ -150,15 +148,15 @@ class KaldiASR(ASRInterface):
         """ This defines asynchronous interface for speech recognition.
 
         Returns:
-            ASR hypotheses in  about the input speech audio.
+            ASR hypotheses.
         """
 
         # Get hypothesis
-        self.decoder.prune_final()
+        self.decoder.finalize_decoding()
         utt_lik, lat = self.decoder.get_lattice()  # returns acceptor (py)fst.LogVectorFst
         self.last_lattice = lat
 
-        self.decoder.reset(keep_buffer_data=False)
+        self.decoder.reset(reset_pipeline=False)
 
         # Convert lattice to word nblist
         return lattice_to_word_posterior_lists(lat, self.n_best)

--- a/alex/resources/default.cfg
+++ b/alex/resources/default.cfg
@@ -234,7 +234,7 @@ config = {
             'silent_phones': online_update('applications/PublicTransportInfoCS/hclg/models/silence.csl'),
             'hclg': online_update('applications/PublicTransportInfoCS/hclg/models/HCLG_tri2b_bmmi.fst'),
             'wst': online_update('applications/PublicTransportInfoCS/hclg/models/words.txt'),
-            'extra_args': '  --max-mem=10000000000 --lat-lm-scale=10 --beam=12.0 --lattice-beam=6.0 --max-active=5000',
+            'extra_args': '  --max-mem=10000000000 --acoustic-scale=0.1 --beam=12.0 --lattice-beam=6.0 --max-active=5000',
         },
         'Google': {
             'debug': False,


### PR DESCRIPTION
Fix kaldi interface changes.
The not visible change in the code is removing the lm-scale option.
Other changes are documented in PR diff and are simply functions renaming.
The --acoustic-scale option should be used instead

--acoustic-scale = 1/ lm_weight_value

where lm_weight_value is the best value from rescoring with lattices during evaluating the AM in the training script

The interface changes were tested by running
alex/applications/PublicTransportInfoCS/hclg/run_decode_indomain_kaldi.sh