### PR TITLE
Fix for missing confirm() and deny() templates

### DIFF
--- a/alex/applications/PublicTransportInfoCS/nlg_templates.cfg
+++ b/alex/applications/PublicTransportInfoCS/nlg_templates.cfg
@@ -876,16 +876,6 @@ templates = {
     'inform(time={time})':
         "V {time}",
 
-    'affirm()&inform(from_stop={from_stop})':
-        "Ano. Jede to ze zastávky {from_stop}.",
-    'negate()&deny(from_stop={from_stop_1})&inform(from_stop={from_stop_2})':
-        "Ne. Nejede to ze zastávky {from_stop_1}, jede to ze zastávky {from_stop_2}.",
-
-    'affirm()&inform(to_stop={to_stop})':
-        "Ano. Jede to do zastávky {to_stop}.",
-    'negate()&deny(to_stop={to_stop_1})&inform(to_stop={to_stop_2})':
-        "Ne. Nejede to do zastávky {to_stop_1}, jede to do zastávky {to_stop_2}.",
-
     'inform(from_stop="{from_stop}")&inform(vehicle="{vehicle}")&inform(line="{line}")&inform(departure_time_rel="{departure_time_rel}")':
         "{vehicle} číslo {line} ze zastávky {from_stop} jede za {departure_time_rel}.",
 
@@ -897,6 +887,105 @@ templates = {
             'Je {current_time}.',
             'Je právě {current_time}.',
         ),
+
+    'affirm()&inform(from_stop="{from_stop}")':
+        "Ano, jede to ze zastávky {from_stop}.",
+    'affirm()&inform(to_stop="{to_stop}")':
+        "Ano, jede to do zastávky {to_stop}.",
+    'affirm()&inform(via_stop="{via_stop}")':
+        "Ano, jede to přes zastávku {via_stop}.",
+    'affirm()&inform(from_city="{from_city}")':
+        "Ano, jede to z obce {from_city}.",
+    'affirm()&inform(to_city="{to_city}")':
+        "Ano, jede to do obce {to_city}.",
+    'affirm()&inform(via_city="{via_city}")':
+        "Ano, jede to přes obec {via_city}.",
+    'affirm()&inform(departure_time="{departure_time}")':
+        "Ano, jede to v {departure_time}.",
+    'affirm()&inform(arrival_time="{arrival_time}")':
+        "Ano, přijede to v {arrival_time}.",
+    'affirm()&inform(departure_time_rel="{departure_time}")':
+        "Ano, jede to za {departure_time_rel}.",
+    'affirm()&inform(arrival_time_rel="{arrival_time_rel}")':
+        "Ano, přijede to za {arrival_time_rel}.",
+    'affirm()&inform(time="{time}")':
+        "Ano, je to v {time}.",
+    'affirm()&inform(time_rel="{time_rel}")':
+        "Ano, je to za {time_rel}.",
+    'affirm()&inform(ampm="{ampm}")':
+        "Ano, je to {ampm}.",
+    'affirm()&inform(date="{date}")':
+        "Ano, je to {date}.",
+    'affirm()&inform(date_rel="{date_rel}")':
+        "Ano, je to {date_rel}.",
+    'affirm()&inform(vehicle="{vehicle}")':
+        "Ano, je to {vehicle}.",
+
+    'negate()&deny(from_stop="{from_stop}")':
+        "Ne, nejede to ze zastávky {from_stop}.",
+    'negate()&deny(to_stop="{to_stop}")':
+        "Ne, nejede to do zastávky {to_stop}.",
+    'negate()&deny(via_stop="{via_stop}")':
+        "Ne, nejede to přes zastávku {via_stop}.",
+    'negate()&deny(from_city="{from_city}")':
+        "Ne, nejede to z obce {from_city}.",
+    'negate()&deny(to_city="{to_city}")':
+        "Ne, nejede to do obce {to_city}.",
+    'negate()&deny(via_city="{via_city}")':
+        "Ne, nejede to přes obec {via_city}.",
+    'negate()&deny(departure_time="{departure_time}")':
+        "Ne, nejede to v {departure_time}.",
+    'negate()&deny(arrival_time="{arrival_time}")':
+        "Ne, nepřijede to v {arrival_time}.",
+    'negate()&deny(departure_time_rel="{departure_time}")':
+        "Ne, nejede to za {departure_time_rel}.",
+    'negate()&deny(arrival_time_rel="{arrival_time_rel}")':
+        "Ne, nepřijede to za {arrival_time_rel}.",
+    'negate()&deny(time="{time}")':
+        "Ne, není to v {time}.",
+    'negate()&deny(time_rel="{time_rel}")':
+        "Ne, není to za {time_rel}.",
+    'negate()&deny(ampm="{ampm}")':
+        "Ne, není to {ampm}.",
+    'negate()&deny(date="{date}")':
+        "Ne, není to {date}.",
+    'negate()&deny(date_rel="{date_rel}")':
+        "Ne, není to {date_rel}.",
+    'negate()&deny(vehicle="{vehicle}")':
+        "Ne, není to {vehicle}.",
+
+    'negate()&deny(from_stop={from_stop_1})&inform(from_stop={from_stop_2})':
+        "Ne. Nejede to ze zastávky {from_stop_1}, jede to ze zastávky {from_stop_2}.",
+    'negate()&deny(to_stop={to_stop_1})&inform(to_stop={to_stop_2})':
+        "Ne. Nejede to do zastávky {to_stop_1}, jede to do zastávky {to_stop_2}.",
+    'negate()&deny(via_stop={via_stop_1})&inform(via_stop={via_stop_2})':
+        "Ne, nejede to přes zastávku {via_stop_1}, jede to přes zastávku {via_stop_2}.",
+    'negate()&deny(from_city={from_city_1})&inform(from_city={from_city_2})':
+        "Ne, nejede to z obce {from_city_1}, jede to z obce {from_city_2}.",
+    'negate()&deny(to_city={to_city_1})&inform(to_city={to_city_2})':
+        "Ne, nejede to do obce {to_city_1}, jede to do obce {to_city_2}.",
+    'negate()&deny(via_city={via_city_1})&inform(via_city={via_city_2})':
+        "Ne, nejede to přes obec {via_city_1}, jede to přes obec {via_city_2}.",
+    'negate()&deny(departure_time={departure_time_1})&inform(departure_time={departure_time_2})':
+        "Ne, nejede to v {departure_time_1}, jede to v {departure_time_2}.",
+    'negate()&deny(arrival_time={arrival_time_1})&inform(arrival_time={arrival_time_2})':
+        "Ne, nepřijede to v {arrival_time_1}, přijede to v {arrival_time_2}.",
+    'negate()&deny(departure_time_rel={departure_time_rel_1})&inform(departure_time_rel={departure_time_rel_2})':
+        "Ne, nejede to za {departure_time_rel_1}, jede to za {departure_time_rel_2}.",
+    'negate()&deny(arrival_time_rel={arrival_time_rel_1})&inform(arrival_time_rel={arrival_time_rel_2})':
+        "Ne, nepřijede to za {arrival_time_rel_1}, přijede to za {arrival_time_rel_2}.",
+    'negate()&deny(time={time_1})&inform(time={time_2})':
+        "Ne, není to v {time_1}, je to v {time_2}.",
+    'negate()&deny(time_rel={time_rel_1})&inform(time_rel={time_rel_2})':
+        "Ne, není to za {time_rel_1}, je to za {time_rel_2}.",
+    'negate()&deny(ampm={ampm_1})&inform(ampm={ampm_2})':
+        "Ne, není to {ampm_1}, je to {ampm_2}.",
+    'negate()&deny(date={date_1})&inform(date={date_2})':
+        "Ne, není to {date_1}, je to {date_2}.",
+    'negate()&deny(date_rel={date_rel_1})&inform(date_rel={date_rel_2})':
+        "Ne, není to {date_rel_1}, je to {date_rel_2}.",
+    'negate()&deny(vehicle={vehicle_1})&inform(vehicle={vehicle_2})':
+        "Ne, není to {vehicle_1}, je to {vehicle_2}.",
 
     #
     # weather-related templates


### PR DESCRIPTION
Adding templates for ``deny`` and ``confirm`` for all slots. Not all of them will ever be issued by the DM, but at least we may be sure that TTS won't crash :-).