### PR TITLE
Fixing auto-download & adding inflection to "expanded" train names

### DIFF
--- a/alex/applications/PublicTransportInfoCS/data/database.py
+++ b/alex/applications/PublicTransportInfoCS/data/database.py
@@ -91,6 +91,7 @@ TRAIN_NAMES_FNAME = "train_names.expanded.txt"
 # load new stops & cities list from the server if needed
 online_update(to_project_path(os.path.join(os.path.dirname(os.path.abspath(__file__)), STOPS_FNAME)))
 online_update(to_project_path(os.path.join(os.path.dirname(os.path.abspath(__file__)), CITIES_FNAME)))
+online_update(to_project_path(os.path.join(os.path.dirname(os.path.abspath(__file__)), TRAIN_NAMES_FNAME)))
 
 
 def db_add(category_label, value, form):


### PR DESCRIPTION
``trains.expanded.txt`` are now automatically downloaded from Vystadial (this is actually needed to make a clean checkout of Alex work).

In addition, ``expand_stops.py`` is now able to inflect train names. I have uploaded the inflected names on Vystadial.