### PR TITLE
Fixing the DA issued in apologies where origin and destination stops are the same

### DIFF
--- a/alex/applications/PublicTransportInfoCS/hdc_policy.py
+++ b/alex/applications/PublicTransportInfoCS/hdc_policy.py
@@ -1056,7 +1056,8 @@ class PTICSHDCPolicy(DialoguePolicy):
         # origin and destination are the same
         if (wp.from_city == wp.to_city) and (wp.from_stop in [wp.to_stop, None]):
             apology_da = DialogueAct('apology()&inform(stops_conflict="thesame")')
-            apology_da.extend(DialogueAct(wp.get_minimal_info()))
+            apology_da.extend(DialogueAct('inform(from_stop="%s")&inform(to_stop="%s")' %
+                                          (wp.from_stop, wp.to_stop)))
             return apology_da
         # origin stop incompatible with origin city
         elif not self.ontology.is_compatible('city_stop', wp.from_city, wp.from_stop):


### PR DESCRIPTION
The DA issued in apologies where the origin and destination stops are
the same should not contain information about vehicle type and number
of transfers. It is irrelevant for the error message and not handled
in NLG templates, which causes confusing prompts, such as:

    Něco tady mám špatně. Předpokládám, že nechcete jet ze stanice Anděl do stanice Anděl. Jeďte autobusem