### PR TITLE
A simple fix for a missing transport type (substitute bus service)

### DIFF
--- a/alex/applications/PublicTransportInfoCS/data/ontology.py
+++ b/alex/applications/PublicTransportInfoCS/data/ontology.py
@@ -354,6 +354,7 @@ ontology = {
             'ferry': 'přívozem',
             'trolleybus': 'trolejbusem',
             'substitute_traffic': 'náhradní dopravou',
+            'substitute_bus': 'náhradním autobusem',
         },
         'date_rel': {
             'today': 'dnes',

--- a/alex/applications/PublicTransportInfoCS/directions.py
+++ b/alex/applications/PublicTransportInfoCS/directions.py
@@ -329,7 +329,8 @@ class CRWSRouteStep(RouteStep):
                             'trolley bus': 'trolleybus',
                             'trolleybus': 'trolleybus',
                             'ship': 'ferry',
-                            'substitute traffic': 'substitute_traffic'}
+                            'substitute traffic': 'substitute_traffic',
+                            'substitute traffic - Bus': 'substitute_bus'}
 
     def __init__(self, travel_mode, input_data, finder=None):
         super(CRWSRouteStep, self).__init__(travel_mode)


### PR DESCRIPTION
This is a fix based on a error report that I received today. The problem is a previously unknown vehicle type (substitute bus service).

The error report is attached below:
```
    TO: (ArrayOfGlobalListItemInfo){
       GlobalListItemInfo[] =
          (GlobalListItemInfo){
             _iItem = 1039
             _sName = "Maniny"
             _iListID = 301003
          },
     }

    TIME_STAMP: 2015-03-17 13:15:00
    IS_DEPARTURE: True


2015-03-17--13-14-48.169768-CET  DM-7       : INFO
    CRWS Directions response:
    (async search in progress)

2015-03-17--13-14-48.175419-CET  DM-7       : INFO
    CRWS Request for additional routes:

    HANDLE: 148410366, LIMIT: 1

2015-03-17--13-14-48.196704-CET  DM-7       : EXCEPTION
    Uncaught exception in the DM process.
    Traceback (most recent call last):
      File "/mnt/h/jurcicek/github/UFAL-DSG-alex-prd/alex/components/hub/dm.py", line 263, in run
        self.read_slu_hypotheses_write_dialogue_act()
[...]
      File "/mnt/h/jurcicek/github/UFAL-DSG-alex-prd/alex/applications/PublicTransportInfoCS/directions.py", line 339, in __init__
        self.vehicle = self.VEHICLE_TYPE_MAPPING[input_data.oTrainData.oInfo._sTypeName]
    KeyError: substitute traffic - Bus
```