### PR TITLE
Fixing weird behavior when the user requests something straight away

### DIFF
--- a/alex/applications/PublicTransportInfoCS/hdc_policy.py
+++ b/alex/applications/PublicTransportInfoCS/hdc_policy.py
@@ -590,13 +590,18 @@ class PTICSHDCPolicy(DialoguePolicy):
                 if len(req_da) == 0:
                     ds.conn_info = conn_info
                     res_da = iconfirm_da
-                    # search for directions, but do not return the output DAs
-                    self.get_directions(ds, check_conflict=True)
+                    # the search will change ds['route_alternative'] if a route is found
+                    dir_da = self.get_directions(ds, check_conflict=True)
+                    # only return the output DAs if no route is found (i.e., the error message),
+                    # otherwise we go on to return the specific information requested
+                    if not isinstance(ds['route_alternative'], int):
+                        res_da.extend(dir_da)
                 # we don't know enough, ask about the rest
                 else:
                     res_da = req_da
 
             # we have a route, so return information about it
+            # NB: ds['route_alternative'] might have changed in the meantime if a route has been found
             if isinstance(ds['route_alternative'], int):
                 if slot == 'from_stop':
                     res_da.extend(self.req_from_stop(ds))


### PR DESCRIPTION
If the user wanted a specific information about the route right at the
beginning of the dialogue, Alex would say that it doesn't know the
origin and destination stops, even though the user provided this in the
sentence:

```
2015-03-17--22-53-16.897861-CET  NLG-8      : DEBUG      
    NLG Output
    ------------------------------------------------------------
    Dobrý den, tady Alex, informace o veřejné dopravě. Hovor je nahráván. Jak Vám můžu pomoci?

2015-03-17--22-53-23.623287-CET  ASR-5      : DEBUG      
    ASR Hypothesis
    ------------------------------------------------------------
    0.472 DOBRÝ DEN ZA JAK DLOUHO JEDE AUTOBUS Z POLIKLINIKY MODŘANY NA PAVELKOVU _NOISE_

2015-03-17--22-53-24.069118-CET  NLG-8      : DEBUG      
    NLG Output
    ------------------------------------------------------------
    Dobře, ze zastávky Poliklinika Modřany do zastávky Pavelkova. Dobře, chcete jet autobusem. Promiňte, ale nevím, odkud a kam chcete jet.
```

This fix first tries to search for a connection, then returns the
specified info, or an error if the connection search failed because of
missing information.