### PR TITLE
Fix launching PTICS for any directory.

### DIFF
--- a/alex/applications/PublicTransportInfoCS/shub
+++ b/alex/applications/PublicTransportInfoCS/shub
@@ -1,5 +1,8 @@
 #!/bin/bash
 
-cd ..
+vhub_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+pushd $vhub_dir 
 
 ./shub.py -c ./PublicTransportInfoCS/ptics.cfg
+
+popd

--- a/alex/applications/PublicTransportInfoCS/shub_google
+++ b/alex/applications/PublicTransportInfoCS/shub_google
@@ -1,5 +1,8 @@
 #!/bin/bash
 
-cd ..
+vhub_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+pushd $vhub_dir 
 
 ./shub.py -c ./PublicTransportInfoCS/ptics.cfg ./PublicTransportInfoCS/google.cfg
+
+popd

--- a/alex/applications/PublicTransportInfoCS/thub
+++ b/alex/applications/PublicTransportInfoCS/thub
@@ -1,5 +1,8 @@
 #!/bin/bash
 
-cd ..
+vhub_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+pushd $vhub_dir 
 
 ./thub.py -c ./PublicTransportInfoCS/ptics.cfg -t
+
+popd

--- a/alex/applications/PublicTransportInfoCS/thub_google
+++ b/alex/applications/PublicTransportInfoCS/thub_google
@@ -5,6 +5,9 @@ export LC_ALL="$LANG"
 export LANGUAGE="$LANG"
 
 
-cd ..
+vhub_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+pushd $vhub_dir 
 
 ./thub.py -c ./PublicTransportInfoCS/ptics.cfg ./PublicTransportInfoCS/google.cfg -t
+
+popd

--- a/alex/applications/PublicTransportInfoCS/thub_google_hdc_slu
+++ b/alex/applications/PublicTransportInfoCS/thub_google_hdc_slu
@@ -1,5 +1,8 @@
 #!/bin/bash
 
-cd ..
+vhub_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+pushd $vhub_dir 
 
 ./thub.py -c ./PublicTransportInfoCS/ptics.cfg ./PublicTransportInfoCS/google.cfg ./PublicTransportInfoCS/ptics_hdc_slu.cfg ../resources/except_hook.cfg -t
+
+popd

--- a/alex/applications/PublicTransportInfoCS/vhub_live_google
+++ b/alex/applications/PublicTransportInfoCS/vhub_live_google
@@ -1,5 +1,8 @@
 #!/bin/bash
 
-cd ..
+vhub_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+pushd $vhub_dir 
 
 ./vhub.py -c ./PublicTransportInfoCS/ptics.cfg ./PublicTransportInfoCS/ptics_live.cfg ../resources/private/ext-800899998.cfg ./PublicTransportInfoCS/nfs.cfg 
+
+popd

--- a/alex/applications/PublicTransportInfoCS/vhub_live_google_b1
+++ b/alex/applications/PublicTransportInfoCS/vhub_live_google_b1
@@ -1,5 +1,8 @@
 #!/bin/bash
 
-cd ..
+vhub_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+pushd $vhub_dir 
 
 ./vhub.py -c ./PublicTransportInfoCS/ptics.cfg ./PublicTransportInfoCS/ptics_live.cfg ../resources/private/ext-800899998b1.cfg ./PublicTransportInfoCS/nfs.cfg 
+
+popd

--- a/alex/applications/PublicTransportInfoCS/vhub_live_google_b2
+++ b/alex/applications/PublicTransportInfoCS/vhub_live_google_b2
@@ -1,5 +1,9 @@
 #!/bin/bash
 
-cd ..
+
+vhub_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+pushd $vhub_dir 
 
 ./vhub.py -c ./PublicTransportInfoCS/ptics.cfg ./PublicTransportInfoCS/ptics_live.cfg ../resources/private/ext-800899998b2.cfg ./PublicTransportInfoCS/nfs.cfg 
+
+popd

--- a/alex/applications/PublicTransportInfoCS/vhub_live_kaldi
+++ b/alex/applications/PublicTransportInfoCS/vhub_live_kaldi
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-pushd ..
+vhub_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+pushd $vhub_dir 
 
 for A in {1..1000}
 do

--- a/alex/applications/PublicTransportInfoCS/vhub_live_kaldi_b1
+++ b/alex/applications/PublicTransportInfoCS/vhub_live_kaldi_b1
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-pushd ..
+vhub_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+pushd $vhub_dir 
 
 for A in {1..1000}
 do

--- a/alex/applications/PublicTransportInfoCS/vhub_live_kaldi_b2
+++ b/alex/applications/PublicTransportInfoCS/vhub_live_kaldi_b2
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-pushd ..
+vhub_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+pushd $vhub_dir 
 
 for A in {1..1000}
 do

--- a/alex/applications/PublicTransportInfoCS/vhub_live_kaldi_mff
+++ b/alex/applications/PublicTransportInfoCS/vhub_live_kaldi_mff
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-pushd ..
+vhub_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+pushd $vhub_dir 
 
 ./vhub.py -c ./PublicTransportInfoCS/ptics.cfg ./PublicTransportInfoCS/ptics_live.cfg ./PublicTransportInfoCS/kaldi.cfg ./PublicTransportInfoCS/nfs.cfg 
 

--- a/alex/applications/PublicTransportInfoCS/vhub_private_ext_google
+++ b/alex/applications/PublicTransportInfoCS/vhub_private_ext_google
@@ -1,5 +1,8 @@
 #!/bin/bash
 
-cd ..
+vhub_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+pushd $vhub_dir 
 
 ./vhub.py -c ./PublicTransportInfoCS/ptics.cfg ./PublicTransportInfoCS/private_ext.cfg  ./PublicTransportInfoCS/google.cfg
+
+popd

--- a/alex/applications/PublicTransportInfoCS/vhub_private_ext_google_kaldi
+++ b/alex/applications/PublicTransportInfoCS/vhub_private_ext_google_kaldi
@@ -1,5 +1,8 @@
 #!/bin/bash
 
-cd ..
+vhub_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+pushd $vhub_dir 
 
 ./vhub.py -c ./PublicTransportInfoCS/ptics.cfg ./PublicTransportInfoCS/private_ext.cfg ./PublicTransportInfoCS/google.cfg ./PublicTransportInfoCS/kaldi.cfg
+
+popd

--- a/alex/applications/PublicTransportInfoCS/vhub_staging
+++ b/alex/applications/PublicTransportInfoCS/vhub_staging
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-pushd ..
+vhub_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+pushd $vhub_dir 
 
 ./vhub.py -c ./PublicTransportInfoCS/ptics.cfg ../resources/private/ext-lz-277278199.cfg ./PublicTransportInfoCS/kaldi.cfg
-
 
 popd

--- a/alex/applications/PublicTransportInfoCS/vhub_test
+++ b/alex/applications/PublicTransportInfoCS/vhub_test
@@ -1,5 +1,8 @@
 #!/bin/bash
 
-cd ..
+vhub_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+pushd $vhub_dir 
 
 ./vhub.py -c ./PublicTransportInfoCS/ptics.cfg
+
+popd

--- a/alex/applications/PublicTransportInfoCS/vhub_test_google
+++ b/alex/applications/PublicTransportInfoCS/vhub_test_google
@@ -1,5 +1,8 @@
 #!/bin/bash
 
-cd ..
+vhub_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+pushd $vhub_dir 
 
 ./vhub.py -c ./PublicTransportInfoCS/ptics.cfg ./PublicTransportInfoCS/google.cfg
+
+popd

--- a/alex/applications/PublicTransportInfoCS/vhub_test_google_hdc_slu
+++ b/alex/applications/PublicTransportInfoCS/vhub_test_google_hdc_slu
@@ -1,5 +1,8 @@
 #!/bin/bash
 
-cd ..
+vhub_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+pushd $vhub_dir 
 
 ./vhub.py -c ./PublicTransportInfoCS/ptics.cfg ./PublicTransportInfoCS/google.cfg ./PublicTransportInfoCS/ptics_hdc_slu.cfg
+
+popd

--- a/alex/applications/PublicTransportInfoCS/vhub_test_google_kaldi
+++ b/alex/applications/PublicTransportInfoCS/vhub_test_google_kaldi
@@ -1,5 +1,8 @@
 #!/bin/bash
 
-cd ..
+vhub_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+pushd $vhub_dir 
 
 ./vhub.py -c ./PublicTransportInfoCS/ptics.cfg ./PublicTransportInfoCS/google.cfg ./PublicTransportInfoCS/kaldi.cfg
+
+popd

--- a/alex/applications/PublicTransportInfoCS/vhub_test_kaldi
+++ b/alex/applications/PublicTransportInfoCS/vhub_test_kaldi
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-pushd ..
+vhub_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+pushd $vhub_dir 
 
 ./vhub.py -c ./PublicTransportInfoCS/ptics.cfg ./PublicTransportInfoCS/kaldi.cfg
 

--- a/alex/applications/PublicTransportInfoCS/vhub_test_kaldi_hdc_slu
+++ b/alex/applications/PublicTransportInfoCS/vhub_test_kaldi_hdc_slu
@@ -1,5 +1,8 @@
 #!/bin/bash
 
-cd ..
+vhub_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+pushd $vhub_dir 
 
 ./vhub.py -c ./PublicTransportInfoCS/ptics.cfg ./PublicTransportInfoCS/kaldi.cfg ./PublicTransportInfoCS/ptics_hdc_slu.cfg
+
+popd

--- a/alex/applications/PublicTransportInfoCS/vhub_test_kaldi_nfs
+++ b/alex/applications/PublicTransportInfoCS/vhub_test_kaldi_nfs
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-pushd ..
+vhub_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+pushd $vhub_dir 
 
 ./vhub.py -c ./PublicTransportInfoCS/ptics.cfg ./PublicTransportInfoCS/kaldi.cfg ./PublicTransportInfoCS/nfs.cfg 
 


### PR DESCRIPTION
Introducing 
```
vhub_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
pushd $vhub_dir 
```
for scripts `vhub_*`, `thub_*`, `shub_*` in PtiCS

so the scripts can be launch from whatever directory and not only from `alex/alex/applications/PublicTransportInfoCS`