### PR TITLE
Inflecting city names if found in dictionary

### DIFF
--- a/alex/applications/PublicTransportInfoCS/cs_morpho.py
+++ b/alex/applications/PublicTransportInfoCS/cs_morpho.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+"""Wrappers for Morphodita Czech morphology analyzer and generator."""
+
+from ufal.morphodita import Tagger, Forms, TaggedLemmas, TokenRanges, Morpho, TaggedLemmasForms
+import re
+
+
+class Analyzer(object):
+    """Morphodita analyzer/tagger wrapper."""
+
+    def __init__(self, tagger_model):
+        self.__tagger = Tagger.load(tagger_model)
+        self.__tokenizer = self.__tagger.newTokenizer()
+        self.__forms_buf = Forms()
+        self.__tokens_buf = TokenRanges()
+        self.__lemmas_buf = TaggedLemmas()
+
+    def analyze(self, stop_text):
+        self.__tokenizer.setText(stop_text)
+        while self.__tokenizer.nextSentence(self.__forms_buf, self.__tokens_buf):
+            self.__tagger.tag(self.__forms_buf, self.__lemmas_buf)
+            return [(form, lemma.lemma, lemma.tag)
+                    for (form, lemma) in zip(self.__forms_buf, self.__lemmas_buf)]
+
+
+class Generator(object):
+    """Morphodita generator wrapper, with support for inflecting
+    noun phrases (stop/city names, personal names)."""
+
+    def __init__(self, morpho_model):
+        self.__morpho = Morpho.load(morpho_model)
+        self.__out_buf = TaggedLemmasForms()
+
+    def generate(self, lemma, tag_wildcard, capitalized=None):
+        """Get variants for one word from the Morphodita generator. Returns
+        empty list if nothing found in the dictionary."""
+        # run the generation for this word
+        self.__morpho.generate(lemma, tag_wildcard, self.__morpho.GUESSER, self.__out_buf)
+        # see if we found any forms, return empty if not
+        if not self.__out_buf:
+            return []
+        # prepare capitalization
+        cap_func = lambda string: string
+        if capitalized == True:
+            cap_func = lambda string: string[0].upper() + string[1:]
+        elif capitalized == False:
+            cap_func = lambda string: string[0].lower() + string[1:]
+        # process the results
+        return [cap_func(form_tag.form) for form_tag in self.__out_buf[0].forms]
+
+    def inflect(self, words, case, personal_names=False, check_fails=False):
+        """Inflect a stop/city/personal name in the given case (return 
+        lists of inflection variants for all words).
+        
+        @param words: list of form/lemma/tag triplets from the analyzer to be inflected
+        @param case: the target case (Czech, 1-7)
+        @param personal_names: should be False for stops/cities, True for personal names
+        @param check_fails: if True, return None if the form is not in the dictionary"""
+        forms = []
+        prev_tag = ''
+        for word in words:
+            form_list = self.__inflect_word(word, case, prev_tag)
+            if not form_list:
+                if check_fails:
+                    return None
+                form_list = [word[0]]
+            forms.append(form_list)
+            prev_tag = word[2]
+        return forms
+
+    def __inflect_word(self, word, case, prev_tag, personal_names=False):
+        """Inflect one word in the given case (return a list of variants,
+        None if the generator fails)."""
+        form, lemma, tag = word
+        # inflect each word in nominative not following a noun in nominative
+        # (if current case is not nominative), avoid numbers
+        if (re.match(r'^[^C]...1', tag) and
+                (not re.match(r'^NN..1', prev_tag) or personal_names) and
+                form not in ['římská'] and
+                case != '1'):
+            # change the case in the tag, allow all variants
+            new_tag = re.sub(r'^(....)1(.*).$', r'\g<1>' + case + r'\g<2>?', tag)
+            # -ice: test both sg. and pl. versions
+            if (form.endswith('ice') and form[0] == form[0].upper() and
+                    not re.match(r'(nemocnice|ulice|vrátnice)', form, re.IGNORECASE)):
+                new_tag = re.sub(r'^(...)S', r'\1[SP]', new_tag)
+            # try inflecting, return empty list if not found in the dictionary
+            capitalized = form[0] == form[0].upper()
+            new_forms = self.generate(lemma, new_tag, capitalized)
+            return new_forms
+        else:
+            return [form]
+

--- a/alex/applications/PublicTransportInfoCS/data/expand_stops.py
+++ b/alex/applications/PublicTransportInfoCS/data/expand_stops.py
@@ -25,52 +25,11 @@ import re
 from collections import defaultdict
 import itertools
 import codecs
-from ufal.morphodita import Tagger, Forms, TaggedLemmas, TokenRanges, Morpho, TaggedLemmasForms
 
 from alex.utils.config import online_update
 from alex.utils.various import remove_dups_stable
+from alex.applications.PublicTransportInfoCS.cs_morpho import Analyzer, Generator 
 from getopt import getopt
-
-
-class Analyzer(object):
-    """Morphodita analyzer/tagger wrapper."""
-
-    def __init__(self, tagger_model):
-        self.__tagger = Tagger.load(tagger_model)
-        self.__tokenizer = self.__tagger.newTokenizer()
-        self.__forms_buf = Forms()
-        self.__tokens_buf = TokenRanges()
-        self.__lemmas_buf = TaggedLemmas()
-
-    def analyze(self, stop_text):
-        self.__tokenizer.setText(stop_text)
-        while self.__tokenizer.nextSentence(self.__forms_buf, self.__tokens_buf):
-            self.__tagger.tag(self.__forms_buf, self.__lemmas_buf)
-            return [(form, lemma.lemma, lemma.tag)
-                    for (form, lemma) in zip(self.__forms_buf, self.__lemmas_buf)]
-
-
-class Generator(object):
-    """Morphodita generator wrapper."""
-
-    def __init__(self, morpho_model):
-        self.__morpho = Morpho.load(morpho_model)
-        self.__out_buf = TaggedLemmasForms()
-
-    def generate(self, lemma, tag_wildcard, capitalized=None):
-        # run the generation for this word
-        self.__morpho.generate(lemma, tag_wildcard, self.__morpho.GUESSER, self.__out_buf)
-        # see if we found any forms, return empty if not
-        if not self.__out_buf:
-            return []
-        # prepare capitalization
-        cap_func = lambda string: string
-        if capitalized == True:
-            cap_func = lambda string: string[0].upper() + string[1:]
-        elif capitalized == False:
-            cap_func = lambda string: string[0].lower() + string[1:]
-        # process the results
-        return [cap_func(form_tag.form) for form_tag in self.__out_buf[0].forms]
 
 
 class ExpandStops(object):
@@ -149,11 +108,7 @@ class ExpandStops(object):
                     words = self.__analyzer.analyze(variant)
                     # in all required cases
                     for case in self.cases_list:
-                        forms = []
-                        prev_tag = ''
-                        for word in words:
-                            forms.append(self.__inflect_word(word, case, prev_tag))
-                            prev_tag = word[2]
+                        forms = self.__generator.inflect(words, case, self.personal_names)
                         # use all possible combinations if there are more variants for this case
                         inflected = map(self.__postprocess_func,
                                         remove_dups_stable([' '.join(var)
@@ -163,28 +118,6 @@ class ExpandStops(object):
                 if ctr % 1000 == 0:
                     print >> sys.stderr, '.',
         print >> sys.stderr
-
-    def __inflect_word(self, word, case, prev_tag):
-        """Inflect one word in the given case (return a list of variants)."""
-        form, lemma, tag = word
-        # inflect each word in nominative not following a noun in nominative
-        # (if current case is not nominative), avoid numbers
-        if (re.match(r'^[^C]...1', tag) and
-                (not re.match(r'^NN..1', prev_tag) or self.personal_names) and
-                form not in ['římská'] and
-                case != '1'):
-            # change the case in the tag, allow all variants
-            new_tag = re.sub(r'^(....)1(.*).$', r'\g<1>' + case + r'\g<2>?', tag)
-            # -ice: test both sg. and pl. versions
-            if (form.endswith('ice') and form[0] == form[0].upper() and
-                    not re.match(r'(nemocnice|ulice|vrátnice)', form, re.IGNORECASE)):
-                new_tag = re.sub(r'^(...)S', r'\1[SP]', new_tag)
-            # try inflecting, fallback to uninflected
-            capitalized = form[0] == form[0].upper()
-            new_forms = self.__generator.generate(lemma, new_tag, capitalized)
-            return new_forms if new_forms else [form]
-        else:
-            return [form]
 
 
 def main():

--- a/alex/applications/PublicTransportInfoCS/nlg_templates.cfg
+++ b/alex/applications/PublicTransportInfoCS/nlg_templates.cfg
@@ -236,61 +236,61 @@ templates = {
         ),
 
     'apology()&inform(from_city={from_city})&inform(to_city={to_city})':
-        "Promiňte, žádné spojení z obce {from_city} do obce {to_city} jsem nenašla.",
+        "Promiňte, žádné spojení z {from_city/Infl 2 obce} do {to_city/Infl 2 obce} jsem nenašla.",
 
     'apology()&inform(from_city={from_city})&inform(from_stop={from_stop})&inform(to_city={to_city})':
-        "Promiňte, žádné spojení ze zastávky {from_stop} v obci {from_city} do obce {to_city} jsem nenašla.",
+        "Promiňte, žádné spojení ze zastávky {from_stop} v {from_city/Infl 6 obci} do {to_city/Infl 2 obce} jsem nenašla.",
 
     'apology()&inform(from_city={from_city})&inform(to_city={to_city})&inform(to_stop={to_stop})':
-        "Promiňte, žádné spojení z obce {from_city} do zastávky {to_stop} v obci {to_city} jsem nenašla.",
+        "Promiňte, žádné spojení z {from_city/Infl 2 obce} do zastávky {to_stop} v {to_city/Infl 6 obci} jsem nenašla.",
 
     'apology()&inform(from_city={from_city})&inform(from_stop={from_stop})&inform(to_city={to_city})&inform(to_stop={to_stop})':
-        "Promiňte, žádné spojení ze zastávky {from_stop} v obci {from_city} do zastávky {to_stop} v obci {to_city} jsem nenašla.",
+        "Promiňte, žádné spojení ze zastávky {from_stop} v {from_city/Infl 6 obci} do zastávky {to_stop} v {to_city/Infl 6 obci} jsem nenašla.",
 
     'apology()&inform(from_stop={from_stop})&inform(to_stop={to_stop})&inform(vehicle={vehicle})':
         "Promiňte, žádné spojení {vehicle} ze zastávky {from_stop} do zastávky {to_stop} jsem nenašla.",
 
     'apology()&inform(from_city={from_city})&inform(to_city={to_city})&inform(vehicle={vehicle})':
-        "Promiňte, žádné spojení {vehicle} z obce {from_city} do obce {to_city} jsem nenašla.",
+        "Promiňte, žádné spojení {vehicle} z {from_city/Infl 2 obce} do {to_city/Infl 2 obce} jsem nenašla.",
 
     'apology()&inform(from_city={from_city})&inform(from_stop={from_stop})&inform(to_city={to_city})&inform(vehicle={vehicle})':
-        "Promiňte, žádné spojení {vehicle} ze zastávky {from_stop} v obci {from_city} do obce {to_city} jsem nenašla.",
+        "Promiňte, žádné spojení {vehicle} ze zastávky {from_stop} v {from_city/Infl 6 obci} do {to_city/Infl 2 obce} jsem nenašla.",
 
     'apology()&inform(from_city={from_city})&inform(to_city={to_city})&inform(to_stop={to_stop})&inform(vehicle={vehicle})':
-        "Promiňte, žádné spojení {vehicle} z obce {from_city} do zastávky {to_stop} v obci {to_city} jsem nenašla.",
+        "Promiňte, žádné spojení {vehicle} z {from_city/Infl 2 obce} do zastávky {to_stop} v {to_city/Infl 6 obci} jsem nenašla.",
 
     'apology()&inform(from_city={from_city})&inform(from_stop={from_stop})&inform(to_city={to_city})&inform(to_stop={to_stop})&inform(vehicle={vehicle})':
-        "Promiňte, žádné spojení {vehicle} ze zastávky {from_stop} v obci {from_city} do zastávky {to_stop} v obci {to_city} jsem nenašla.",
+        "Promiňte, žádné spojení {vehicle} ze zastávky {from_stop} v {from_city/Infl 6 obci} do zastávky {to_stop} v {to_city/Infl 6 obci} jsem nenašla.",
 
     'apology()&inform(from_stop={from_stop})&inform(to_stop={to_stop})&inform(num_transfers={num_transfers})':
         "Promiňte, žádné spojení {num_transfers} ze zastávky {from_stop} do zastávky {to_stop} jsem nenašla.",
 
     'apology()&inform(from_city={from_city})&inform(to_city={to_city})&inform(num_transfers={num_transfers})':
-        "Promiňte, žádné spojení {num_transfers} z obce {from_city} do obce {to_city} jsem nenašla.",
+        "Promiňte, žádné spojení {num_transfers} z {from_city/Infl 2 obce} do {to_city/Infl 2 obce} jsem nenašla.",
 
     'apology()&inform(from_city={from_city})&inform(from_stop={from_stop})&inform(to_city={to_city})&inform(num_transfers={num_transfers})':
-        "Promiňte, žádné spojení {num_transfers} ze zastávky {from_stop} v obci {from_city} do obce {to_city} jsem nenašla.",
+        "Promiňte, žádné spojení {num_transfers} ze zastávky {from_stop} v {from_city/Infl 6 obci} do {to_city/Infl 2 obce} jsem nenašla.",
 
     'apology()&inform(from_city={from_city})&inform(to_city={to_city})&inform(to_stop={to_stop})&inform(num_transfers={num_transfers})':
-        "Promiňte, žádné spojení {num_transfers} z obce {from_city} do zastávky {to_stop} v obci {to_city} jsem nenašla.",
+        "Promiňte, žádné spojení {num_transfers} z {from_city/Infl 2 obce} do zastávky {to_stop} v {to_city/Infl 6 obci} jsem nenašla.",
 
     'apology()&inform(from_city={from_city})&inform(from_stop={from_stop})&inform(to_city={to_city})&inform(to_stop={to_stop})&inform(num_transfers={num_transfers})':
-        "Promiňte, žádné spojení {num_transfers} ze zastávky {from_stop} v obci {from_city} do zastávky {to_stop} v obci {to_city} jsem nenašla.",
+        "Promiňte, žádné spojení {num_transfers} ze zastávky {from_stop} v {from_city/Infl 6 obci} do zastávky {to_stop} v {to_city/Infl 6 obci} jsem nenašla.",
 
     'apology()&inform(from_stop={from_stop})&inform(to_stop={to_stop})&inform(vehicle={vehicle})&inform(num_transfers={num_transfers})':
         "Promiňte, žádné spojení {vehicle} {num_transfers} ze zastávky {from_stop} do zastávky {to_stop} jsem nenašla.",
 
     'apology()&inform(from_city={from_city})&inform(to_city={to_city})&inform(vehicle={vehicle})&inform(num_transfers={num_transfers})':
-        "Promiňte, žádné spojení {vehicle} {num_transfers} z obce {from_city} do obce {to_city} jsem nenašla.",
+        "Promiňte, žádné spojení {vehicle} {num_transfers} z {from_city/Infl 2 obce} do {to_city/Infl 2 obce} jsem nenašla.",
 
     'apology()&inform(from_city={from_city})&inform(from_stop={from_stop})&inform(to_city={to_city})&inform(vehicle={vehicle})&inform(num_transfers={num_transfers})':
-        "Promiňte, žádné spojení {vehicle} {num_transfers} ze zastávky {from_stop} v obci {from_city} do obce {to_city} jsem nenašla.",
+        "Promiňte, žádné spojení {vehicle} {num_transfers} ze zastávky {from_stop} v {from_city/Infl 6 obci} do {to_city/Infl 2 obce} jsem nenašla.",
 
     'apology()&inform(from_city={from_city})&inform(to_city={to_city})&inform(to_stop={to_stop})&inform(vehicle={vehicle})&inform(num_transfers={num_transfers})':
-        "Promiňte, žádné spojení {vehicle} {num_transfers} z obce {from_city} do zastávky {to_stop} v obci {to_city} jsem nenašla.",
+        "Promiňte, žádné spojení {vehicle} {num_transfers} z {from_city/Infl 2 obce} do zastávky {to_stop} v {to_city/Infl 6 obci} jsem nenašla.",
 
     'apology()&inform(from_city={from_city})&inform(from_stop={from_stop})&inform(to_city={to_city})&inform(to_stop={to_stop})&inform(vehicle={vehicle})&inform(num_transfers={num_transfers})':
-        "Promiňte, žádné spojení {vehicle} {num_transfers} ze zastávky {from_stop} v obci {from_city} do zastávky {to_stop} v obci {to_city} jsem nenašla.",
+        "Promiňte, žádné spojení {vehicle} {num_transfers} ze zastávky {from_stop} v {from_city/Infl 6 obci} do zastávky {to_stop} v {to_city/Infl 6 obci} jsem nenašla.",
 
 
     'apology()&inform(stops_conflict="thesame")&inform(from_stop={from_stop})&inform(to_stop={to_stop})':
@@ -307,13 +307,13 @@ templates = {
         ),
 
     'apology()&inform(stops_conflict="thesame")&inform(from_city={from_city})&inform(to_city={to_city})':
-        "Promiňte, asi Vám nerozumím. Předpokládám, že nechcete jet z obce {from_city} do obce {to_city}.",
+        "Promiňte, asi Vám nerozumím. Předpokládám, že nechcete jet z {from_city/Infl 2 obce} do {to_city/Infl 2 obce}.",
 
     'apology()&inform(stops_conflict="thesame")&inform(from_city={from_city})&inform(from_stop={from_stop})&inform(to_city={to_city})':
-        "Promiňte, asi Vám nerozumím. Předpokládám, že nechcete jet ze zastávky {from_stop} v obci {from_city} kamkoliv do obce {to_city}.",
+        "Promiňte, asi Vám nerozumím. Předpokládám, že nechcete jet ze zastávky {from_stop} v {from_city/Infl 6 obci} kamkoliv do {to_city/Infl 2 obce}.",
 
     'apology()&inform(stops_conflict="thesame")&inform(from_city={from_city})&inform(to_city={to_city})&inform(to_stop={to_stop})':
-        "Promiňte, asi Vám nerozumím. Předpokládám, že nechcete jet odkudkoliv z obce {from_city} do zastávky {to_stop} v obci {to_city}.",
+        "Promiňte, asi Vám nerozumím. Předpokládám, že nechcete jet odkudkoliv z {from_city/Infl 2 obce} do zastávky {to_stop} v {to_city/Infl 6 obci}.",
 
     'inform(stops_conflict="thesame")':
         ("Je mi líto, ale asi jsem Vám špatně rozuměla. Jméno výchozí tak i cílové zastávky je stejné.",
@@ -338,10 +338,10 @@ templates = {
         ),
 
     'apology()&inform(stops_conflict="incompatible")&inform(from_city={from_city})&inform(from_stop={from_stop})':
-        "Promiňte, asi Vám nerozumím. Zastávku {from_stop} v obci {from_city} neznám.",
+        "Promiňte, asi Vám nerozumím. Zastávku {from_stop} v {from_city/Infl 6 obci} neznám.",
 
     'apology()&inform(stops_conflict="incompatible")&inform(to_city={to_city})&inform(to_stop={to_stop})':
-        "Promiňte, asi Vám nerozumím. Zastávku {to_stop} v obci {to_city} neznám.",
+        "Promiňte, asi Vám nerozumím. Zastávku {to_stop} v {to_city/Infl 6 obci} neznám.",
 
     'apology()&inform(missed_connection="true")':
         "Tohle spojení Vám už bohužel ujelo. Můžete se ale zeptat na další.",
@@ -497,25 +497,25 @@ templates = {
         ),
 
     'iconfirm(from_city={from_city})':
-        "Z obce {from_city}.",
+        "Z {from_city/Infl 2 obce}.",
 
     'iconfirm(to_city={to_city})':
-        "Do obce {to_city}.",
+        "Do {to_city/Infl 2 obce}.",
 
     'iconfirm(in_city={in_city})':
-        "V obci {in_city}.",
+        "V {in_city/Infl 6 obci}.",
 
     'iconfirm(via_city={via_city})':
-        "Přes obec {via_city}.",
+        "Přes {via_city/Infl 4 obec}.",
 
     'iconfirm(to_city={to_city})&iconfirm(from_city={from_city})':
-        "Dobře, z obce {from_city} do obce {to_city}.",
+        "Dobře, z {from_city/Infl 2 obce} do {to_city/Infl 2 obce}.",
 
     'iconfirm(to_stop={to_stop})&iconfirm(from_stop={from_stop})&iconfirm(to_city={to_city})&iconfirm(from_city={from_city})':
-        "Dobře, ze zastávky {from_stop} v obci {from_city} do zastávky {to_stop} v obci {to_city}.",
+        "Dobře, ze zastávky {from_stop} v {from_city/Infl 6 obci} do zastávky {to_stop} v {to_city/Infl 6 obci}.",
 
     'iconfirm(to_city={to_city})&iconfirm(to_stop={to_stop})&iconfirm(from_stop={from_stop})&iconfirm(from_city={from_city})':
-        "Dobře, ze zastávky {from_stop} v obci {from_city} do zastávky {to_stop} v obci {to_city}.",
+        "Dobře, ze zastávky {from_stop} v {from_city/infl 6 obci} do zastávky {to_stop} v {to_city/Infl 6 obci}.",
 
     'confirm(from_stop={from_stop})':
         ("Chcete jet ze zastávky {from_stop}?",
@@ -533,12 +533,12 @@ templates = {
         "Chcete jet ze zastávky {from_stop} do zastávky {to_stop}?",
 
     'confirm(from_city={from_city})':
-        ("Chcete jet z obce {from_city}?",
-         "Chcete jet z města {from_city}?",),
+        ("Chcete jet z {from_city/Infl 2 obce}?",
+         "Chcete jet z {from_city/Infl 2 města}?",),
 
     'confirm(to_city={to_city})':
-        ("Chcete jet do obce {to_city}?",
-         "Chcete jet do města {to_city}?",),
+        ("Chcete jet do {to_city/Infl 2 obce}?",
+         "Chcete jet do {to_city/Infl 2 města}?",),
 
     'confirm(in_city={in_city})':
         ("Říkáte obec {in_city}?",
@@ -548,7 +548,7 @@ templates = {
         "Chcete jet přes zastávku {via_stop}?",
 
     'confirm(via_city={via_city})':
-        "Chcete jet přes obec {via_city}?",
+        "Chcete jet přes {via_city/Infl 4 obec}?",
 
     'confirm(arrival_time="{arrival_time}")':
         "Takže tam chcete být v {arrival_time}?",
@@ -895,11 +895,11 @@ templates = {
     'affirm()&inform(via_stop="{via_stop}")':
         "Ano, jede to přes zastávku {via_stop}.",
     'affirm()&inform(from_city="{from_city}")':
-        "Ano, jede to z obce {from_city}.",
+        "Ano, jede to z {from_city/Infl 2 obce}.",
     'affirm()&inform(to_city="{to_city}")':
-        "Ano, jede to do obce {to_city}.",
+        "Ano, jede to do {to_city/Infl 2 obce}.",
     'affirm()&inform(via_city="{via_city}")':
-        "Ano, jede to přes obec {via_city}.",
+        "Ano, jede to přes {to_city/Infl 4 obec}.",
     'affirm()&inform(departure_time="{departure_time}")':
         "Ano, jede to v {departure_time}.",
     'affirm()&inform(arrival_time="{arrival_time}")':
@@ -928,11 +928,11 @@ templates = {
     'negate()&deny(via_stop="{via_stop}")':
         "Ne, nejede to přes zastávku {via_stop}.",
     'negate()&deny(from_city="{from_city}")':
-        "Ne, nejede to z obce {from_city}.",
+        "Ne, nejede to z {from_city/Infl 2 obce}.",
     'negate()&deny(to_city="{to_city}")':
-        "Ne, nejede to do obce {to_city}.",
+        "Ne, nejede to do {to_city/Infl 2 obce}.",
     'negate()&deny(via_city="{via_city}")':
-        "Ne, nejede to přes obec {via_city}.",
+        "Ne, nejede to přes {to_city/Infl 4 obec}.",
     'negate()&deny(departure_time="{departure_time}")':
         "Ne, nejede to v {departure_time}.",
     'negate()&deny(arrival_time="{arrival_time}")':
@@ -1001,7 +1001,7 @@ templates = {
         "{date_rel/Cap1} bude {weather_condition}, teploty {min_temperature} až {max_temperature}.",
 
     'apology()&inform(in_city={in_city})':
-        "Omlouvám se, počasí pro obec {in_city} nemám k dispozici.",
+        "Omlouvám se, počasí pro {in_city/Infl 4 obec} nemám k dispozici.",
 
     #
     # Platform info related templates.


### PR DESCRIPTION
Inflecting city names if they are found in the Morphodita dictionary,
i.e., instead of ``z obce Praha``, the NLG component can now output
``z Prahy``. It falls back to ``z obce XY`` if the city name is not in
the dictionary and the generator does not know how to inflect it.

This can be easily extended to stop names, but I'm not sure if we
want that.

I have moved Czech morphology-related code from ``data/expand_stops.py`` to ``cs_morpho.py``
because now it's used both in stop/city name expansion and NLG city name inflection.