### PR TITLE
Moving route_alternative to a special state variable

### DIFF
--- a/alex/applications/PublicTransportInfoCS/data/ontology.py
+++ b/alex/applications/PublicTransportInfoCS/data/ontology.py
@@ -216,10 +216,6 @@ ontology = {
             'system_informs',
             'absolute_time',
         ],
-        'route_alternative': [
-            # this is necessary to be defined as it is a state variable used by the policy and automatically added to
-            # the dialogue state
-        ],
 
         'lta_task': [],
         'lta_bye': [],
@@ -245,6 +241,9 @@ ontology = {
             'user_informs'
         ]
     },
+
+    # additional variables that relate to the state but are not used as slots (initialized to None)
+    'variables': ['route_alternative', 'conn_info', 'directions'],
 
     'context_resolution': {
         # it is used DM belief tracking context that

--- a/alex/components/dm/dddstate.py
+++ b/alex/components/dm/dddstate.py
@@ -270,8 +270,12 @@ class DeterministicDiscriminativeDialogueState(DialogueState):
 
         Nevertheless, remember the turn history.
         """
-
+        # initialize slots
         self.slots = defaultdict(D3DiscreteValue)
+        # initialize other variables
+        if 'variables' in self.ontology:
+            for var_name in self.ontology['variables']:
+                setattr(self, var_name, None)
 
     def update(self, user_da, system_da):
         """Interface for the dialogue act update.


### PR DESCRIPTION
The `dialogue_state` variable is now a member variable of the state object,
(same as `conn_info` and `directions`), not a slot.

This reflects the actual usage of the variable – it is always integer,
never a probability distribution. Now we don't need to use `isinstance`
to test whether a route has been found, we can use `is not None`, which
is nicer.

This also fixes the problem reported in #165.