### PR TITLE
Fix for #168 – avoiding the city of 'none'

### DIFF
--- a/alex/applications/PublicTransportInfoCS/hdc_policy.py
+++ b/alex/applications/PublicTransportInfoCS/hdc_policy.py
@@ -825,8 +825,8 @@ class PTICSHDCPolicy(DialoguePolicy):
                                                                   'time' not in accepted_slots) and randbool(10):
             req_da.extend(DialogueAct('request(departure_time)'))
 
-        # we know the cities, but it's not an intercity connection -- request stops if required
-        elif stop_city_inferred or (from_city_val == to_city_val and from_city_val != 'none'):
+        # we do not know the stops (and they weren't inferred based on cities)
+        elif from_stop_val == 'none' or to_stop_val == 'none':
             if from_stop_val == 'none' and to_stop_val == 'none' and randbool(3):
                 req_da.extend(DialogueAct("request(from_stop)&request(to_stop)"))
             elif from_stop_val == 'none':
@@ -834,7 +834,7 @@ class PTICSHDCPolicy(DialoguePolicy):
             elif to_stop_val == 'none':
                 req_da.extend(DialogueAct('request(to_stop)'))
 
-        # we need to know the cities -- ask about them
+        # we know the stops, but we need to know the cities -- ask about them
         elif from_city_val == 'none':
             req_da.extend(DialogueAct('request(from_city)'))
         elif to_city_val == 'none':


### PR DESCRIPTION
This fixes the bug reported in #168. It had probably been introduced
in fbea940 -- `stop_city_inferred` is true if any of the stops has
a city inferred, which may not hold for the other stop, so it's not
safe to use it at this place.

This also means that now we always ask for the stop first and only
when we're unsure (if the stop is in several different cities), we ask
for the city.

@jurcicek : Are you OK with this behavior, or should I add a `randbool`
for asking about the city?