### PR TITLE
Fixing weather prediction for times that are too soon

### DIFF
--- a/alex/applications/PublicTransportInfoCS/hdc_policy.py
+++ b/alex/applications/PublicTransportInfoCS/hdc_policy.py
@@ -452,7 +452,7 @@ class PTICSHDCPolicy(DialoguePolicy):
         daily = (time_abs == 'none' and ampm == 'none' and date_rel != 'none' and lta_time != 'time_rel')
         # check if any time is set to distinguish current/prediction
         weather_ts = None
-        if time_abs != 'none' or time_rel != 'none' or ampm != 'none' or date_rel != 'none':
+        if time_abs != 'none' or time_rel not in ['none', 'now'] or ampm != 'none' or date_rel != 'none':
             weather_ts, time_type = self.interpret_time(time_abs, ampm, time_rel, date_rel, lta_time)
         # find the coordinates of the city
         city_addinfo = self.ontology['addinfo']['city'].get(in_city, None)

--- a/alex/applications/utils/weather.py
+++ b/alex/applications/utils/weather.py
@@ -35,6 +35,13 @@ class OpenWeatherMapWeather(Weather):
             date = datetime.combine(date.date(), datetime.fromtimestamp(input_json['list'][0]['dt']).time())
         # convert the date/time to Unix timestamp (timezone-independent)
         ts = int(date.strftime("%s"))
+        # ensure that we are within the range returned by OpenWeatherMap
+        # (the weather might be wrong, but at least it doesn't crash if you ask for weather in 5 minutes 
+        # and the returned values start in an hour)
+        if ts < input_json['list'][0]['dt']:
+            ts = input_json['list'][0]['dt']
+        if ts > input_json['list'][-1]['dt']:
+            ts = input_json['list'][-1]['dt']
         for fc1, fc2 in zip(input_json['list'][:-1], input_json['list'][1:]):
             # find the appropriate time frame
             if ts >= fc1['dt'] and ts <= fc2['dt']:


### PR DESCRIPTION
Fixing weather requests for times like "now" or "in five minutes", based on a crash report. Tested with `thub_hdc_slu`.

If you ask for hourly weather forecast, OpenWeatherMap's response time range usually starts in an hour or so, so you get out of range for times that are too soon.

This fix makes two things:
- For "now", you don't ask for forecast, but get the current condition (this only worked previously if you didn't specify any time at all).
- For times that are out of range returned by OpenWeatherMap, the closest weather condition is returned.