### PR TITLE
Fixed CRWS platform info.

### DIFF
--- a/alex-requirements.txt
+++ b/alex-requirements.txt
@@ -23,3 +23,5 @@ sphinxcontrib-napoleon
 
 flask
 theano
+
+ufal.morphodita

--- a/alex/applications/PublicTransportInfoCS/directions.py
+++ b/alex/applications/PublicTransportInfoCS/directions.py
@@ -495,6 +495,20 @@ class CRWSDirectionsFinder(DirectionsFinder, APIRequest):
 
     def search_train_station(self, stop_mask, max_count=0, skip_count=0):
         """Seach train station database in IDOS."""
+        #return self.client.service.SearchTimetableObjectInfo(
+        #    self.user_id,
+        #    self.user_desc,
+        #    self.default_comb_id,
+        #    self.train_list_id,
+        #    stop_mask, # mask
+        #    SEARCHMODE.EXACT | SEARCHMODE.USE_PRIORITY, # search mode
+        #    max_count, # max count
+        #    REG.SMART, # return regions
+        #    skip_count, # skip count
+        #    TTINFODETAILS.STATIONSEXT,
+        #    COOR.DEFAULT,
+        #    TTLANG.ENGLISH # language
+        #)
         return self.client.service.SearchGlobalListItemInfo(
             self.user_id,
             self.user_desc,
@@ -505,10 +519,23 @@ class CRWSDirectionsFinder(DirectionsFinder, APIRequest):
             max_count, # max count
             REG.SMART, # return regions
             skip_count, # skip count
-            TTINFODETAILS.STATIONSEXT,
-            COOR.DEFAULT,
+            #TTINFODETAILS.STATIONSEXT,
+            #COOR.DEFAULT,
             TTLANG.ENGLISH # language
         )
+
+        # SearchGlobalListItemInfo(
+        # xs:string sUserID,
+        # xs:string sUserDesc,
+        # xs:string sCombID,
+        # xs:int iListID,
+        # xs:string sMask,
+        # xs:int iSearchMode,
+        # xs:int iMaxCount,
+        # xs:int iRegMode,
+        # xs:int iSkipCount,
+        # xs:int iLang, )
+
 
     def search_city(self, city_mask):
         return self.search_stop(city_mask, self.city_list_id)
@@ -568,10 +595,11 @@ class CRWSDirectionsFinder(DirectionsFinder, APIRequest):
                 self.user_id,
                 self.user_desc,
                 self.default_comb_id,
-                from_obj[0],
+                from_obj[0][0],
                 True,
                 datetime.min, # timestamp of arrival or departure
                 True,
+                None,
                 SEARCHMODE.EXACT,
                 1,
                 REG.SMART,

--- a/alex/applications/PublicTransportInfoCS/directions.py
+++ b/alex/applications/PublicTransportInfoCS/directions.py
@@ -495,20 +495,6 @@ class CRWSDirectionsFinder(DirectionsFinder, APIRequest):
 
     def search_train_station(self, stop_mask, max_count=0, skip_count=0):
         """Seach train station database in IDOS."""
-        #return self.client.service.SearchTimetableObjectInfo(
-        #    self.user_id,
-        #    self.user_desc,
-        #    self.default_comb_id,
-        #    self.train_list_id,
-        #    stop_mask, # mask
-        #    SEARCHMODE.EXACT | SEARCHMODE.USE_PRIORITY, # search mode
-        #    max_count, # max count
-        #    REG.SMART, # return regions
-        #    skip_count, # skip count
-        #    TTINFODETAILS.STATIONSEXT,
-        #    COOR.DEFAULT,
-        #    TTLANG.ENGLISH # language
-        #)
         return self.client.service.SearchGlobalListItemInfo(
             self.user_id,
             self.user_desc,

--- a/alex/applications/PublicTransportInfoCS/hdc_policy.py
+++ b/alex/applications/PublicTransportInfoCS/hdc_policy.py
@@ -383,6 +383,13 @@ class PTICSHDCPolicy(DialoguePolicy):
                             res_da.append(DialogueActItem('inform', 'direction',
                                                           platform_info.to_stop))
                         else:
+                            if platform_info.directions:
+                                based_on_directions = 'true'
+                            else:
+                                based_on_directions = 'false'
+
+                            res_da.append(DialogueActItem('inform', 'based_on_directions', based_on_directions))
+
                             if platform_res.platform:
                                 res_da.append(DialogueActItem('inform', 'platform',
                                                           platform_res.platform))
@@ -879,11 +886,16 @@ class PTICSHDCPolicy(DialoguePolicy):
         # generate implicit confirms if we inferred cities and they are not the same for both stops
         iconfirm_da = DialogueAct()
 
+        directions = None
+        if ds.directions:
+            directions = ds.directions[ds.route_alternative]
+
         pi  = PlatformInfo(from_stop=from_stop_val,
-                                                 to_stop=to_stop_val,
-                                                 from_city=from_city_val,
-                                                 to_city=to_city_val,
-                                                 train_name=train_name_val)
+                           to_stop=to_stop_val,
+                           from_city=from_city_val,
+                           to_city=to_city_val,
+                           train_name=train_name_val,
+                           directions=directions)
         return req_da, iconfirm_da, pi
 
     def req_current_time(self):

--- a/alex/applications/PublicTransportInfoCS/nlg_templates.cfg
+++ b/alex/applications/PublicTransportInfoCS/nlg_templates.cfg
@@ -1008,17 +1008,21 @@ templates = {
     #
     'request(to_stop)&request(train_name)':
         "A jakým směrem chcete jet? Nebo jak se jmenuje váš vlak?",
-    'inform(platform=none)&inform(track=none)&inform(direction={direction})':
+    'inform(platform=none)&inform(track=none)&inform(direction={direction})&inform(based_on_directions={bod})':
         "Ještě nění známo odkud to jede směrem {direction}.",
     'inform(platform=not_found)&inform(direction={direction})':
         "Spoj do {direction} nebyl nalezen.",
     'inform(platform=not_found)&inform(direction=none)':
         "Spoj nebyl nalezen.",
-    'inform(platform={platform})&inform(track={track})&inform(direction={direction})':
+    'inform(based_on_directions="false")&inform(platform={platform})&inform(track={track})&inform(direction={direction})':
         "Vlak do stanice {direction} jede z nástupiště {platform} kolej {track}.",
-    'inform(platform={platform})&inform(track)&inform(direction={direction})':
+    'inform(based_on_directions="false")&inform(platform={platform})&inform(track)&inform(direction={direction})':
         "Vlak do stanice {direction} jede z nástupiště {platform}.",
-    'inform(platform={platform})&inform(track={track})&inform(train_name={train_name})':
+    'inform(based_on_directions="true")&inform(platform={platform})&inform(track={track})&inform(direction={direction})':
+        "Vyhledaný spoj jede z nástupiště {platform} kolej {track} směrem {direction}.",
+    'inform(based_on_directions="true")&inform(platform={platform})&inform(track)&inform(direction={direction})':
+        "Vyhledaný spoj jede z nástupiště {platform} směrem {direction}.",
+    'inform(based_on_directions={bod})&inform(platform={platform})&inform(track={track})&inform(train_name={train_name})':
         "Vlak {train_name} jede z nástupiště {platform} kolej {track}.",
     'inform(not_supported)': "Bohužel tato funkce není dostupná."
 

--- a/alex/applications/PublicTransportInfoCS/nlg_templates.cfg
+++ b/alex/applications/PublicTransportInfoCS/nlg_templates.cfg
@@ -1008,10 +1008,12 @@ templates = {
     #
     'request(to_stop)&request(train_name)':
         "A jakým směrem chcete jet? Nebo jak se jmenuje váš vlak?",
-    'inform(platform=none)&inform(track=none)&inform(direction={direction})&inform(based_on_directions={bod})':
+    'inform(based_on_directions=true)&inform(platform=none)&inform(track=none)&inform(direction={direction})':
+        "Ještě nění známo odkud to jede směrem {direction}.",
+    'inform(based_on_directions=false)&inform(platform=none)&inform(track=none)&inform(direction={direction})':
         "Ještě nění známo odkud to jede směrem {direction}.",
     'inform(platform=not_found)&inform(direction={direction})':
-        "Spoj do {direction} nebyl nalezen.",
+        "Spoj do zastávky {direction} nebyl nalezen.",
     'inform(platform=not_found)&inform(direction=none)':
         "Spoj nebyl nalezen.",
     'inform(based_on_directions="false")&inform(platform={platform})&inform(track={track})&inform(direction={direction})':
@@ -1022,7 +1024,9 @@ templates = {
         "Vyhledaný spoj jede z nástupiště {platform} kolej {track} směrem {direction}.",
     'inform(based_on_directions="true")&inform(platform={platform})&inform(track)&inform(direction={direction})':
         "Vyhledaný spoj jede z nástupiště {platform} směrem {direction}.",
-    'inform(based_on_directions={bod})&inform(platform={platform})&inform(track={track})&inform(train_name={train_name})':
+    'inform(based_on_directions=true)&inform(platform={platform})&inform(track={track})&inform(train_name={train_name})':
+        "Vlak {train_name} jede z nástupiště {platform} kolej {track}.",
+    'inform(based_on_directions=false)&inform(platform={platform})&inform(track={track})&inform(train_name={train_name})':
         "Vlak {train_name} jede z nástupiště {platform} kolej {track}.",
     'inform(not_supported)': "Bohužel tato funkce není dostupná."
 

--- a/alex/applications/PublicTransportInfoCS/platform_info.py
+++ b/alex/applications/PublicTransportInfoCS/platform_info.py
@@ -3,12 +3,13 @@ import re
 
 
 class PlatformInfo(object):
-    def __init__(self, from_stop, to_stop, from_city, to_city, train_name):
+    def __init__(self, from_stop, to_stop, from_city, to_city, train_name, directions):
         self.from_stop = from_stop
         self.to_stop = to_stop
         self.from_city = from_city
         self.to_city = to_city
         self.train_name = train_name
+        self.directions = directions
 
     def __unicode__(self):
         return u"%s, %s -- %s, %s" % (self.from_stop, self.from_city,
@@ -121,5 +122,3 @@ class CRWSPlatformInfo(object):
                 return PlatformFinderResult(platform, track, train_name)
 
         return None
-
-

--- a/alex/applications/PublicTransportInfoCS/platform_info.py
+++ b/alex/applications/PublicTransportInfoCS/platform_info.py
@@ -73,7 +73,6 @@ class CRWSPlatformInfo(object):
             return x.upper()
 
         names = set(norm(obj._sName) for obj in to_obj[0])
-        print 'names', names
         for entry in self.crws_response.aoRecords:
             # Figure out whether this entry corresponds to the entry the user
             # is interested in.

--- a/alex/applications/PublicTransportInfoCS/platform_info_test.py
+++ b/alex/applications/PublicTransportInfoCS/platform_info_test.py
@@ -1,0 +1,13 @@
+import unittest
+
+from platform_info import CRWSPlatformInfo
+
+
+class PlatformInfoTest(unittest.TestCase):
+    def test_matching(self):
+        x = CRWSPlatformInfo(None, None)
+        self.assertTrue(x._matches('hr.kr.', 'hradec kralove'))
+        self.assertTrue(x._matches('hr.kralove', 'hradec kralove'))
+        self.assertTrue(x._matches('hr.kralove', 'hradec kr.'))
+        self.assertTrue(x._matches('brno hl.n.', 'brno hlavni nadrazi'))
+        self.assertFalse(x._matches('mostek', 'most'))


### PR DESCRIPTION
There was a new parameter `sLine` introduced in the `SearchDepartureTableInfo` API call. I added the current signatures of the calls as comments. In the future we might think about abandoning the WSDL API and using their new REST one `http://docs.crws.apiary.io/`.

I am also adding `ufal.morphodita` dependency which was introduced some time before but forgotten to be added to `requirements.txt`.