### PR TITLE
Bugfix for alternative routes

### DIFF
--- a/alex/applications/PublicTransportInfoCS/hdc_policy.py
+++ b/alex/applications/PublicTransportInfoCS/hdc_policy.py
@@ -519,7 +519,7 @@ class PTICSHDCPolicy(DialoguePolicy):
         :param ds: The current dialogue state
         :rtype: DialogueAct
         """
-        if ds.route_alternative is not None:
+        if ds.route_alternative is None:
             return DialogueAct('request(from_stop)')
         else:
             ds.route_alternative += 1


### PR DESCRIPTION
Alex crashed or behaved strangely if the user asked for an alternative route, due to a stupid bug (swapped True/False for a test) introduced by me in fe0b991 . This fixes the problem.