### PR TITLE
Fixing number of transfers

### DIFF
--- a/alex/applications/PublicTransportInfoCS/directions.py
+++ b/alex/applications/PublicTransportInfoCS/directions.py
@@ -810,7 +810,7 @@ class CRWSDirectionsFinder(DirectionsFinder, APIRequest):
         params._iMaxArcLengthTo = 4
         params._iNodeFrom = 1
         params._iNodeTo = 1
-        # TODO number of transfers (_iMaxChange)
+
         if parameters is not None:
             # vehicle type limitations (IDs taken from CRWS)
             if parameters.vehicle == 'train':

--- a/alex/applications/PublicTransportInfoCS/hdc_policy.py
+++ b/alex/applications/PublicTransportInfoCS/hdc_policy.py
@@ -782,7 +782,7 @@ class PTICSHDCPolicy(DialoguePolicy):
         from_city_val = self.get_accepted_mpv(ds, 'from_city', accepted_slots)
         to_city_val = self.get_accepted_mpv(ds, 'to_city', accepted_slots)
         vehicle_val = self.get_accepted_mpv(ds, 'vehicle', accepted_slots)
-        max_transfers_val = self.get_accepted_mpv(ds, 'max_transfers', accepted_slots)
+        num_transfers_val = self.get_accepted_mpv(ds, 'num_transfers', accepted_slots)
 
         # infer cities based on stops
         from_cities, to_cities = None, None
@@ -855,7 +855,7 @@ class PTICSHDCPolicy(DialoguePolicy):
 
         return req_da, iconfirm_da, Travel(from_city=from_city_val, from_stop=from_stop_val,
                                            to_city=to_city_val, to_stop=to_stop_val,
-                                           vehicle=vehicle_val, max_transfers=max_transfers_val)
+                                           vehicle=vehicle_val, max_transfers=num_transfers_val)
 
     def gather_platform_info(self, ds, accepted_slots):
         """Return a DA requesting further information for the platform search.


### PR DESCRIPTION
Due to a bug I commited in 60d2b3b, the maximum number of transfers
specified by the user has been ignored (there is a variable name mismatch – the slot is called `num_transfers`, but the variable in CRWS direction finder is called `max_transfers`). This changes the variable name so that the value is passed on.