### PR TITLE
Bugfix -- correct backoff for cities not in morphological dictionary

### DIFF
--- a/alex/applications/PublicTransportInfoCS/preprocessing.py
+++ b/alex/applications/PublicTransportInfoCS/preprocessing.py
@@ -6,10 +6,9 @@ from __future__ import unicode_literals
 
 from alex.components.slu.base import SLUPreprocessing
 from alex.components.asr.utterance import Utterance
-#from alex.utils.czech_stemmer import cz_stem
 from alex.components.nlg.template import TemplateNLGPreprocessing
 from alex.components.nlg.tools.cs import word_for_number
-from alex.applications.PublicTransportInfoCS.cs_morpho import Analyzer, Generator 
+from alex.applications.PublicTransportInfoCS.cs_morpho import Analyzer, Generator
 from alex.utils.config import online_update
 import re
 import string
@@ -47,7 +46,7 @@ class PTICSSLUPreprocessing(SLUPreprocessing):
 
     def normalise_utterance(self, utterance):
         utterance = super(PTICSSLUPreprocessing, self).normalise_utterance(utterance)
-        #utterance = Utterance(" ".join(map(cz_stem, utterance)))
+        # utterance = Utterance(" ".join(map(cz_stem, utterance)))
         return utterance
 
 
@@ -89,7 +88,6 @@ class PTICSNLGPreprocessing(TemplateNLGPreprocessing):
         generator_model = online_update('applications/PublicTransportInfoCS/data/czech.dict')
         self._analyzer = Analyzer(analyzer_model)
         self._generator = Generator(generator_model)
-
 
     def preprocess(self, template, svs_dict):
         """Preprocess values to be filled into an NLG template.
@@ -133,9 +131,10 @@ class PTICSNLGPreprocessing(TemplateNLGPreprocessing):
                 _, case, repl_word = modif.split(' ')
                 words = self._analyzer.analyze(svs_dict[slot])
                 forms = self._generator.inflect(words, case, check_fails=True)
-                if not forms:
+                if forms:
+                    svs_dict[slot] = ' '.join([f[0] for f in forms])
+                else:
                     svs_dict[slot] = repl_word + ' ' + svs_dict[slot]
-                svs_dict[slot] = ' '.join([vars[0] for vars in forms])
 
         return template, svs_dict
 


### PR DESCRIPTION
Due to a bug in city names inflection introduced by me in 32c5c78, the system would crash if the morphological generator fails inflecting a city name.

This fixes it by introducing a correct backoff as originally intended. E.g., if the system fails inflecting *‘Bašť’* in genitive for the phrase *‘do Baště’*, it returns *‘do obce Bašť’* instead.