### PR TITLE
PTIEN – CF jobs store call log path, (improved) task description

### DIFF
--- a/alex/components/hub/dm.py
+++ b/alex/components/hub/dm.py
@@ -168,8 +168,11 @@ class DM(multiprocessing.Process):
         self.commands.send(DMDA(da, 'DM', 'HUB'))
 
     def epilogue_final_code(self):
+
         data = None
         attempts = 0
+        url_template = self.cfg['DM']['epilogue']['final_code_url']
+        system_logger = self.cfg['Logging']['system_logger']
 
         # store a code on the server (try several times if not successful)
         while attempts < 10 and not data or not data['response'] or data['response'] != 'success':
@@ -177,7 +180,7 @@ class DM(multiprocessing.Process):
             self.codes.append(code)  # put the code back to the end of the queue for reuse
             attempts += 1
             # pull the URL
-            url = self.cfg['DM']['epilogue']['final_code_url'].format(code=code)
+            url = url_template.format(code=code, logdir=system_logger.get_session_dir_name())
             data = urllib2.urlopen(url).read()
             data = json.loads(data, encoding='UTF-8')
 
@@ -315,5 +318,5 @@ class DM(multiprocessing.Process):
             otherwise CF contributor would do the job without getting paid.
         """
         if self.cfg['DM']['epilogue']['final_question'] is None and self.cfg['DM']['epilogue']['final_code_url'] is not None:
-            url = self.cfg['DM']['epilogue']['final_code_url'].format(code='test')
+            url = self.cfg['DM']['epilogue']['final_code_url'].format(code='test', logdir='')
             urllib2.urlopen(url)

--- a/alex/tools/crowdflower/CFJOB-PTIEN.css
+++ b/alex/tools/crowdflower/CFJOB-PTIEN.css
@@ -29,10 +29,13 @@
   color: #00A6E0;
 }
 
-li {
-font-family: "Lato",sans-serif;
-font-weight: 400;
-line-height: 150%;
+#task p {
+  font-size: 13pt;
+  margin: 0 0;
+}
+
+#task {
+  margin-top: 10px;
 }
 
 th{

--- a/alex/tools/crowdflower/CFJOB-PTIEN.html
+++ b/alex/tools/crowdflower/CFJOB-PTIEN.html
@@ -84,6 +84,10 @@
   <div class="feedback">
     <cml:text label="Dialogue Code validation field:" name="code_field" validates="required yext_no_international_url" instructions="In order to obtain this Code you have to successfully complete the call. Please wait until the code is verified." />
 
+    <cml:hidden name="call_log_dir" value="" />
+    <cml:hidden name="task_text" value="" />
+    <cml:hidden name="task_data" value="" />
+
     <cml:radios validates="required" label="Have you found what you were looking for?">
       <cml:radio label="Yes" />
       <cml:radio label="No" />

--- a/alex/tools/crowdflower/task_templates.cfg
+++ b/alex/tools/crowdflower/task_templates.cfg
@@ -7,129 +7,276 @@ templates = {
     'say(text={text})':
         '{text}',
 
-    'inform(task="find_connection")':
-        (
-            [
-                ("You are looking for", "Ask about"),
-                ("a transit schedule.", "a connection.", "an itinerary.", "a public transit route."),
-            ],
-        ),
-
-    'inform(from_stop={from_stop})':
-        (   
-            [
-                ("Your departure stop is", "You are leaving from", "You want to go from",
-                 "You are departing from", "Your departure place is", "Your place of departure is"),
-                ("{from_stop}. ",),
-            ],
-        ),
-
-    'inform(to_stop={to_stop})':
-        (   
-            [
-                ("Tell the system that", "Say that", "State that", "Inform the system that"),
-                ("your destination stop is", "you are going to", "you want to go to", 
-                 "you want to get to", "you are heading to", "your destination is"),
-                ("{to_stop}. ",),
-            ],
-        ),
-    
     'inform(task="find_connection")&inform(from_stop={from_stop})&inform(to_stop={to_stop})':
         (
             [
-                ("Ask about a connection", "You want to go", "You want to travel", "Ask about a transit itinerary",
-                 "Ask about a trip", "Ask about a schedule", "Ask about a transit schedule", "Ask about a route",
-                 "Ask about a journey", "You are looking for a journey", "You are looking for transit options", 
-                 "You are looking for a schedule", "You are looking for a transit connection",),
-                ("from {from_stop} to {to_stop}."),
+                ("Ask about", "You are looking for", "Tell the system that you are looking for",
+                 "Ask the system about", "Try asking for", "Do as if you are looking for",
+                 "You need", "You search for", "You want to know", "You want", "You are searching for",),
+                ("a connection", "a transit itinerary", "a trip", "a schedule", "a transit schedule", "a route",
+                 "a public transit route", "transit options", "public transport", "a journey",
+                 "a ride",),
+                (", and let's say that", " – ", ",", ",", ",",),
+                ("your departure stop is", "you are leaving from", "you want to go from",
+                 "you are departing from", "your departure place is", "your place of departure is",),
+                ("<i>{from_stop}</i>",),
+                (", and",),
+                ("your destination stop is", "you are going to", "you want to go to",
+                 "you want to get to", "you are heading to", "your destination is",),
+                ("<i>{to_stop}</i>.",),
+            ],
+            [
+                ("Ask about", "You are looking for", "Tell the system that you are looking for",
+                 "Ask the system about", "Try asking for", "Do as if you are looking for",
+                 "You need", "You search for", "You want to know", "You want", "You are searching for",),
+                ("a connection", "a transit itinerary", "a trip", "a schedule", "a transit schedule", "a route",
+                 "a public transit route", "transit options", "public transport", "a journey",
+                 "a ride",),
+                ("departing from", "going from", "from", "leaving from", "starting from",),
+                ("<i>{from_stop}</i>",),
+                ("to", "for", "and going to", "and heading to", "with the destination of",),
+                ("<i>{to_stop}</i>.",),
+            ],
+            [
+                ("You are", "Tell the system that you are", "Do as if you are",),
+                ("departing from", "going from", "travelling from", "leaving from", "starting from",),
+                ("<i>{from_stop}</i>",),
+                ("to", "and you are going to", "and you are heading to", "and your destination is",
+                 "and you want to get to", "and heading towards",),
+                ("<i>{to_stop}</i>.",),
+            ],
+            [
+                ("You want to know how to", "You need to know how to", "You want to", "Let's say that you want to",
+                 "Tell the system that you want to", "Do as if you want to",),
+                ("go", "travel", "get",),
+                ("from <i>{from_stop}</i> to <i>{to_stop}</i>.",),
+            ],
+            [
+                ("You want to know how to", "You need to know how to", "You want to", "Let's say that you want to",
+                 "Tell the system that you want to", "Do as if you want to",),
+                ("start", "depart", "leave",),
+                ("from <i>{from_stop}</i> and",),
+                ("go to", "travel to", "get to", "finish at", "head towards",),
+                ("<i>{to_stop}</i>.",),
             ],
         ),
- 
-    'inform(task="find_connection")&inform(from_stop={from_stop})&inform(to_stop={to_stop})':
+
+    'request(duration)&request(arrival_time)':
         (
             [
-                ("You are going", "You want to go", "You want to travel", "You are traveling",
-                 "You are heading"),
-                ("from {from_stop} to {to_stop}."),
+                ("When you are offered", "When the system offers you",),
+                ("a schedule,", "a trip,", "an itinerary,",),
+                ("ask about",),
+                ("its duration", "the duration", "the time needed",),
+                ("and",),
+                ("the arrival time.", "your arrival time.", "the time of your arrival.",),
             ],
-            "You want to start from {from_stop} and go to {to_stop}.",
+            [
+                ("When you are offered", "When the system offers you",),
+                ("a schedule,", "a trip,", "an itinerary,",),
+                ("ask",),
+                ("how long it will take", "how much time it takes", "how long it takes",
+                 "how mich time you need",),
+                ("and",),
+                ("when", "at what time",),
+                ("you will be at your destination.", "you will be at the destination.", "you will be there.",
+                "you will arrive at your destination.", "you will arrive at the destination.", "you will arrive.",
+                "you will get to your destination.", "you will get to the destination.", "you will get there.",
+                "you will reach your destination.", "you will reach the destination.",),
+            ],
+            [
+                ("Try asking about some details:", "Talk about the details:", "You want to know more:", "",),
+                ("Ask about the duration of", "Ask about time needed for the",),
+                ("the ride", "the trip", "the journey", "your trip", "your journey", "your ride",),
+                ("and about", "and", "and find out the", "and request that the system tells you",),
+                ("the arrival time", "the time of arrival",),
+                ("at the destination.", "at your destination.", ".",),
+            ],
+            [
+                ("Try asking about some details:", "Talk about the details:", "You want to know more:", "",),
+                ("Ask how long",),
+                ("it", "the ride", "the trip", "the journey", "your trip", "your journey", "your ride",),
+                ("will take",),
+                ("and",),
+                ("when", "at what time",),
+                ("you will be at your destination.", "you will be at the destination.", "you will be there.",
+                "you will arrive at your destination.", "you will arrive at the destination.", "you will arrive.",
+                "you will get to your destination.", "you will get to the destination.", "you will get there.",
+                "you will reach your destination.", "you will reach the destination.",),
+            ],
+            [
+                ("Try asking about some details:", "Talk about the details:", "You want to know more:", "",),
+                ("Ask how long it will take",),
+                ("to get there", "to reach your destination", "to reach the destination",
+                 "to get to the destination",),
+                ("and",),
+                ("when", "at what time",),
+                ("you will be there.", "you will arrive.", "you will get there.",),
+            ],
+
         ),
 
     'request(duration)':
-        ( 
+        (
             [
-                ("Ask about the duration of", "Ask about time needed for the", ),
-                ("the ride.", "the trip.", "the journey.", "your trip.", "your journey.", "your ride."),
-            ], 
+                ("When you are offered", "When the system offers you",),
+                ("a schedule,", "a trip,", "an itinerary,",),
+                ("ask",),
+                ("about its duration.", "about the duration.", "about the time needed.", "how long it will take.",
+                 "how much time it takes.", "how long it takes.",),
+            ],
             [
-                ("Ask how long", ),
-                ("it", "the ride", "the trip", "the journey", "your trip", "your journey", "your ride"),
-                ("will take.", ),
+                ("Ask about the duration of", "Ask about time needed for the",),
+                ("the ride.", "the trip.", "the journey.", "your trip.", "your journey.", "your ride.",),
+            ],
+            [
+                ("Ask how long",),
+                ("it", "the ride", "the trip", "the journey", "your trip", "your journey", "your ride",),
+                ("will take.",),
             ],
             [
                 ("Ask how long it will take",),
-                ("to get there.", "to reach your destination.", "to reach the destination.", 
-                 "to get to the destination."),
+                ("to get there.", "to reach your destination.", "to reach the destination.",
+                 "to get to the destination.",),
             ],
         ),
- 
+
     'request(arrival_time)':
-        ( 
+        (
+            [
+                ("When you are offered", "When the system offers you",),
+                ("a schedule,", "a trip,", "an itinerary,",),
+                ("ask about the",),
+                ("arrival time", "time of arrival",),
+                ("at the destination.", "at your destination.", ".",),
+            ],
             [
                 ("Ask about the",),
                 ("arrival time", "time of arrival",),
-                ("at the destination.", "at your destination.", "."),
+                ("at the destination.", "at your destination.", ".",),
             ],
             [
-                ("Ask when", "Ask at what time"),
-                ("you will be", "you will arrive"), 
-                ("there.", "at your destination.", "at the destination."),
+                ("When you are offered", "When the system offers you",),
+                ("a schedule,", "a trip,", "an itinerary,",),
+                ("ask when", "ask at what time",),
+                ("you will be", "you will arrive",),
+                ("there.", "at your destination.", "at the destination.",),
             ],
             [
-                ("Ask when", "Ask at what time"),
-                ("you will reach",), 
-                ("your destination.", "the destination."),
+                ("Ask when", "Ask at what time",),
+                ("you will be", "you will arrive",),
+                ("there.", "at your destination.", "at the destination.",),
+            ],
+            [
+                ("When you are offered", "When the system offers you",),
+                ("a schedule,", "a trip,", "an itinerary,",),
+                ("ask when", "ask at what time",),
+                ("you will reach",),
+                ("your destination.", "the destination.",),
+            ],
+            [
+                ("Ask when", "Ask at what time",),
+                ("you will reach",),
+                ("your destination.", "the destination.",),
             ],
         ),
 
     'inform(alternative="next")':
-         ( 
+         (
             [
-                ("Ask about", "Ask for", "Request information about"),
-                ("a next", "a following", "another", "a subsequent", "a later"),
-                ("connection.", "ride.", "schedule.", "option.", "alternative."),
+                ("Then ask about", "Then ask for", "Subsequently, ask about", "Subsequently, ask for",
+                 "Ask about", "Ask for", "Request information about",
+                 "Try asking for", "Try asking about",),
+                ("a next", "a following", "another", "a subsequent", "a later",),
+                ("connection.", "ride.", "schedule.", "option.", "alternative.",),
             ],
             [
-                ("Ask about", "Ask for", "Request information about"),
-                ("a connection", "a ride", "a schedule", "an option", "an alternative"),
-                ("after that.", "after.", "afterwards.", "at a later time."),
+                ("Subsequently, ask about", "Subsequently, ask for", "Then ask about", "Then ask for",
+                 "Ask about", "Ask for", "Request information about",
+                 "Try asking for", "Try asking about",),
+                ("a connection", "a ride", "a schedule", "an option", "an alternative",),
+                ("after that.", "after.", "afterwards.", "at a later time.",),
             ],
         ),
 
-    'inform(time="6:00")&inform(ampm="evening")':
-         ( 
+    'inform(vehicle="bus")&inform(time="6:00")&inform(ampm="evening")':
+         (
             [
-                ("Ask about", "Ask for", "Request information about"),
-                ("a connection", "a ride", "a schedule", "an option", "an alternative"),
-                ("at six", "at 6"),
+                ("Then modify your", "Try modifying your", "Change your", "Try changing your",
+                 "Alter your", "Try altering your", "Then alter your", "Then change your", "Modify your",),
+                ("request:", "search:", "query:",),
+                ("Ask about", "Ask for", "Request information about",),
+                ("a connection", "a ride", "a schedule", "an option", "an alternative",),
+                ("at six", "at 6",),
+                ("o'clock p.m.", "p.m.", "in the evening.", "o'clock in the evening.",),
+                ("Ask about", "Ask for", "Request information about",),
+                ("a bus connection.", "a connection by bus.", "a bus option.",),
+            ],
+            [
+                ("Then modify your", "Try modifying your", "Change your", "Try changing your",
+                 "Alter your", "Try altering your", "Then alter your", "Then change your", "Modify your",),
+                ("request:", "search:", "query:",),
+                ("Ask about", "Ask for", "Request information about",),
+                ("a connection", "a ride", "a schedule", "an option", "an alternative",),
+                ("at six", "at 6",),
+                ("o'clock p.m.", "p.m.", "in the evening", "o'clock in the evening",),
+                ("and",),
+                ("say that you want to", "tell the system that you would rather",
+                 "say that you would prefer to", "state that you prefer to",),
+                ("go by bus.", "take the bus.", "use the bus.",),
+            ],
+
+         ),
+
+    'inform(time="6:00")&inform(ampm="evening")':
+         (
+            [
+                ("Change your departure time:", "", "Change your time of departure:",),
+                ("Ask about", "Ask for", "Request information about",),
+                ("a connection", "a ride", "a schedule", "an option", "an alternative",),
+                ("at six", "at 6",),
                 ("o'clock p.m.", "p.m.", "in the evening.", "o'clock in the evening.",)
             ],
         ),
 
     'inform(vehicle="bus")':
-         ( 
+         (
             [
-                ("Ask about", "Ask for", "Request information about"),
-                ("a bus connection.", "a connection by bus.", "a bus option."),
+                ("Now,", "Then,", "Subsequently,", "Specify your needs and", "Try and",),
+                ("ask about", "ask for", "request information about",),
+                ("a bus connection.", "a connection by bus.", "a bus option.",),
             ],
             [
                 ("Say that you want to", "Tell the system that you would rather",
-                 "You want to", "You would like to", "You would rather", 
-                 "Say that you would prefer to", "State that you prefer to"),
-                ("go by bus.", "take the bus"),
+                 "You want to", "You would like to", "You would rather", "Try saying that you want to",
+                 "Say that you would prefer to", "State that you prefer to",),
+                ("go by bus.", "take the bus.", "use the bus.",),
             ],
         ),
 
-    
- 
+
+    'inform(to_stop={to_stop})':
+        (
+            [
+                ("Try changing your plans:", "Do as if you changed your mind:", "Change your mind:",),
+                ("Tell the system that", "Say that", "State that", "Inform the system that",),
+                ("your destination stop is", "you are going to", "you want to go to",
+                 "you want to get to", "you are heading to", "your destination is",),
+                ("<i>{to_stop}</i>.",),
+            ],
+            [
+                ("Finally,", "As the last request,", "At the end,"),
+                ("try changing your plans:", "do as if you changed your mind:", "change your mind:",),
+                ("Tell the system that", "Say that", "State that", "Inform the system that",),
+                ("your destination stop is", "you are going to", "you want to go to",
+                 "you want to get to", "you are heading to", "your destination is",),
+                ("<i>{to_stop}</i>.",),
+            ],
+            [
+                ("Finally, change", "As the last request, change", "Change",),
+                ("the destination", "your destination", "your destination stop", "the destination stop",),
+                ("<i>to {to_stop}</i>.",),
+            ],
+        ),
+
 }


### PR DESCRIPTION
1. Task assignment descriptions for the PTIEN CF jobs are now "improved" – they try to appear as prose and force the user not to repeat them word-by-word.

2. The CF job now stores task assignments (in text and DAs) as well as call log directory. The call log directory is passed by the DM hub to the code server, and it passed on to the CF job upon veryfing the code.